### PR TITLE
feat: created new workflow for release zip with current version

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,7 +2,7 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - main
+      - release-file-fix
 jobs:
   bumpversion:
     runs-on: ubuntu-latest
@@ -84,6 +84,15 @@ jobs:
           commit_sha: ${{ needs.bumpversion.outputs.bump_commit_sha }}
           default_bump: false
           default_prerelease_bump: false
+          
+      - name: Create a GitHub release
+        if: steps.tag_version.outputs.new_tag
+        uses: ncipollo/release-action@v1
+        with:
+          tag: ${{ steps.tag_version.outputs.new_tag }}
+          name: Release ${{ steps.tag_version.outputs.new_tag }}
+          body: ${{ steps.tag_version.outputs.changelog }}
+          artifacts: "openedx-woocommerce-plugin.zip"
 
       - name: Install Composer dependencies
         uses: "ramsey/composer-install@v2"
@@ -96,12 +105,3 @@ jobs:
           type: 'zip'
           filename: 'openedx-woocommerce-plugin.zip'
           exclusions: '*.git*'
-          
-      - name: Create a GitHub release
-        if: steps.tag_version.outputs.new_tag
-        uses: ncipollo/release-action@v1
-        with:
-          tag: ${{ steps.tag_version.outputs.new_tag }}
-          name: Release ${{ steps.tag_version.outputs.new_tag }}
-          body: ${{ steps.tag_version.outputs.changelog }}
-          artifacts: "openedx-woocommerce-plugin.zip"

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -2,7 +2,7 @@ name: Continuous Integration
 on:
   push:
     branches:
-      - release-file-fix
+      - main
 jobs:
   bumpversion:
     runs-on: ubuntu-latest
@@ -93,15 +93,3 @@ jobs:
           name: Release ${{ steps.tag_version.outputs.new_tag }}
           body: ${{ steps.tag_version.outputs.changelog }}
           artifacts: "openedx-woocommerce-plugin.zip"
-
-      - name: Install Composer dependencies
-        uses: "ramsey/composer-install@v2"
-        with:
-          composer-options: "--no-dev"
-
-      - name: Archive Release
-        uses: thedoctor0/zip-release@0.7.1
-        with:
-          type: 'zip'
-          filename: 'openedx-woocommerce-plugin.zip'
-          exclusions: '*.git*'

--- a/.github/workflows/upload-release-zip.yml
+++ b/.github/workflows/upload-release-zip.yml
@@ -25,7 +25,7 @@ jobs:
         uses: thedoctor0/zip-release@0.7.1
         with:
           type: 'zip'
-          filename: 'openedx-ecommerce.zip'
+          filename: 'openedx-commerce.zip'
           exclusions: '*.git*'
 
       - name: Upload zip to latest release
@@ -33,6 +33,6 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.WC_PAT }}
         with:
-          file: "openedx-ecommerce.zip"
+          file: "openedx-commerce.zip"
           update_latest_release: true
           draft: false

--- a/.github/workflows/upload-release-zip.yml
+++ b/.github/workflows/upload-release-zip.yml
@@ -1,0 +1,38 @@
+name: Build & Upload zip
+
+# Only trigger, when the build workflow succeeded
+on:
+  workflow_run:
+    workflows: ["Continuous Integration"]
+    types:
+      - completed
+
+jobs:
+  upload_zip:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+            token: ${{ secrets.WC_PAT }}
+
+      - name: Install Composer dependencies
+        uses: "ramsey/composer-install@v2"
+        with:
+          composer-options: "--no-dev"
+
+      - name: Archive Release
+        uses: thedoctor0/zip-release@0.7.1
+        with:
+          type: 'zip'
+          filename: 'openedx-ecommerce.zip'
+          exclusions: '*.git*'
+
+      - name: Upload zip to latest release
+        uses: xresloader/upload-to-github-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.WC_PAT }}
+        with:
+          file: "openedx-ecommerce.zip"
+          update_latest_release: true
+          draft: false


### PR DESCRIPTION
## Description

An important error in the release generation process has been corrected. Previously, when generating a release, the 'zip' file of the plugin was being created with dependencies still tagged with the previous version. In other words, if transitioning from v1.0.0 to v2.0.0, the version tag in the files remained as v1.0.0 due to a workflow order issue.

To address this, we now allow the 'bumpversion' workflow to execute, and only after its successful completion, the 'upload-release-zip.yml' process is triggered. This process generates a zip file with the current version tag and adds it to the finalized release.

## Testing instructions

"For testing purposes, it's best to fork the repository, manually create an initial version tag so that the workflow can recognize that one already exists and know which version to set, and then make a change to the 'main' branch to trigger the workflow.

## Additional information

At the end, a zip file is generated with the name 'openex-ecommerce.zip,' which contains the necessary files and dependencies for the installation. The name has been changed in accordance with the rules required by WordPress.

![image](https://github.com/openedx/openedx-wordpress-ecommerce/assets/52968528/a276ee88-192a-4125-bb1f-c64a55c034f3)
