### PR TITLE
feat: show enrollment status in enrollments table

### DIFF
--- a/includes/model/class-openedx-woocommerce-plugin-api-calls.php
+++ b/includes/model/class-openedx-woocommerce-plugin-api-calls.php
@@ -132,6 +132,10 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 		$access_token        = $this->check_access_token();
 		$access_token_string = $this->get_access_token( $access_token );
 
+		if ( 'save_no_process' === $enrollment_action ) {
+			return array( 'no_process', 'The enrollment process has been skipped, saved locally.' );
+		}
+
 		if ( 'enroll' === $request_type ) {
 
 			if ( 'enrollment_process' === $enrollment_action ) {

--- a/includes/model/class-openedx-woocommerce-plugin-enrollment.php
+++ b/includes/model/class-openedx-woocommerce-plugin-enrollment.php
@@ -146,9 +146,9 @@ class Openedx_Woocommerce_Plugin_Enrollment {
 	 */
 	public function register_status() {
 		register_post_status(
-			'enrollment-success',
+			'success',
 			array(
-				'label'                     => __( 'Success', 'wp-openedx-woocommerce-plugin' ),
+				'label'                     => __( 'success', 'wp-openedx-woocommerce-plugin' ),
 				'public'                    => false,
 				'internal'                  => true,
 				'private'                   => true,
@@ -160,9 +160,23 @@ class Openedx_Woocommerce_Plugin_Enrollment {
 			)
 		);
 		register_post_status(
-			'enrollment-pending',
+			'no_process',
 			array(
-				'label'                     => __( 'Pending', 'wp-openedx-woocommerce-plugin' ),
+				'label'                     => __( 'success', 'wp-openedx-woocommerce-plugin' ),
+				'public'                    => false,
+				'internal'                  => true,
+				'private'                   => true,
+				'exclude_from_search'       => false,
+				'show_in_admin_all_list'    => true,
+				'show_in_admin_status_list' => true,
+				// translators: %s: number of items.
+				'label_count'               => _n_noop( 'No process <span class="count">(%s)</span>', 'No process <span class="count">(%s)</span>', 'wp-openedx-woocommerce-plugin' ),
+			)
+		);
+		register_post_status(
+			'pending',
+			array(
+				'label'                     => __( 'pending', 'wp-openedx-woocommerce-plugin' ),
 				'public'                    => false,
 				'internal'                  => true,
 				'private'                   => true,
@@ -174,9 +188,9 @@ class Openedx_Woocommerce_Plugin_Enrollment {
 			)
 		);
 		register_post_status(
-			'enrollment-error',
+			'error',
 			array(
-				'label'                     => __( 'Error', 'wp-openedx-woocommerce-plugin' ),
+				'label'                     => __( 'error', 'wp-openedx-woocommerce-plugin' ),
 				'public'                    => false,
 				'internal'                  => true,
 				'private'                   => true,
@@ -334,15 +348,11 @@ class Openedx_Woocommerce_Plugin_Enrollment {
 			$this->update_post( $post_id );
 		}
 
-		$non_valid_statuses = array( 'enrollment-success', 'enrollment-pending', 'enrollment-error' );
-
-		// Only update the post status if it has no custom status yet.
-		if ( ! in_array( $post->post_status, $non_valid_statuses, true ) ) {
-			$this->update_post( $post_id, 'enrollment-pending' );
-		}
-
+		$non_valid_statuses      = array( 'enrollment-success', 'enrollment-pending', 'enrollment-error' );
 		$api                     = new Openedx_Woocommerce_Plugin_Api_Calls();
 		$enrollment_api_response = $api->request_handler( $enrollment_data, $enrollment_action );
+
+		$this->update_post( $post_id, $enrollment_api_response[0] );
 		$this->log_manager->create_change_log( $post_id, $old_data, $enrollment_data, $enrollment_action, $enrollment_api_response );
 
 		if ( null !== $order_id ) {
@@ -435,7 +445,7 @@ class Openedx_Woocommerce_Plugin_Enrollment {
 
 		$post_update = array(
 			'ID'         => $post_id,
-			'post_title' => $enrollment_course_id . ' | ' . $enrollment_email . ' | Mode: ' . $enrollment_mode,
+			'post_title' => $enrollment_course_id . ' | ' . $enrollment_email . ' | Mode: ' . $enrollment_mode . ' | Status: ' . $status,
 		);
 
 		if ( $status ) {

--- a/includes/model/class-openedx-woocommerce-plugin-enrollment.php
+++ b/includes/model/class-openedx-woocommerce-plugin-enrollment.php
@@ -348,10 +348,10 @@ class Openedx_Woocommerce_Plugin_Enrollment {
 			$this->update_post( $post_id );
 		}
 
-		$non_valid_statuses      = array( 'enrollment-success', 'enrollment-pending', 'enrollment-error' );
 		$api                     = new Openedx_Woocommerce_Plugin_Api_Calls();
 		$enrollment_api_response = $api->request_handler( $enrollment_data, $enrollment_action );
 
+		// The $enrollment_api_response[0] is the status of the request.
 		$this->update_post( $post_id, $enrollment_api_response[0] );
 		$this->log_manager->create_change_log( $post_id, $old_data, $enrollment_data, $enrollment_action, $enrollment_api_response );
 

--- a/includes/model/class-openedx-woocommerce-plugin-log.php
+++ b/includes/model/class-openedx-woocommerce-plugin-log.php
@@ -85,6 +85,9 @@ class Openedx_Woocommerce_Plugin_Log {
 				return $response_message;
 
 			case 'success':
+				// Convert the response to JSON to be able to display it in the log.
+				// The json_decode is needed to convert the response (string) to an asociative array.
+				// The json_encode is needed to convert the asociative array to a JSON and be able to access the variables.
 				return wp_json_encode( json_decode( $response_message, true ) );
 
 			case 'not_api':

--- a/includes/model/class-openedx-woocommerce-plugin-log.php
+++ b/includes/model/class-openedx-woocommerce-plugin-log.php
@@ -76,19 +76,22 @@ class Openedx_Woocommerce_Plugin_Log {
 	 */
 	public function check_api_response( $response ) {
 
-		switch ( $response[0] ) {
+		$response_status  = $response[0];
+		$response_message = $response[1];
+
+		switch ( $response_status ) {
 
 			case 'error':
-				return $response[1];
+				return $response_message;
 
 			case 'success':
-				return wp_json_encode( json_decode( $response[1], true ) );
+				return wp_json_encode( json_decode( $response_message, true ) );
 
 			case 'not_api':
-				return 'Enrollment saved locally, action does not require an API call';
+				return $response_message;
 
-			default:
-				return 'API did not provide a response';
+			case 'no_process':
+				return $response_message;
 		}
 	}
 


### PR DESCRIPTION
## Description

Now, in the enrollments, an additional piece of information will be displayed, which is the status. The status can be 'success,' 'error,' or 'no process,' indicating whether the last request was successful, encountered an error, or if no process was necessary (in the case of saving the enrollment locally).

## Testing instructions

Pull the branch locally and run the 'composer install' command to install all plugin dependencies and test. 

## Additional information

To filter and search for enrollments based on their status, it's as simple as typing the desired status into the search bar located at the top right corner of the enrollments.

## Checklist for Merge

- [X] Tested in a remote environment
- [ ] Updated documentation N/A
- [ ] Rebased master/main N/A
- [ ] Squashed commits N/A