### PR TITLE
feat: always use force flag or enrollment allowed setting

### DIFF
--- a/admin/views/class-openedx-woocommerce-plugin-settings.php
+++ b/admin/views/class-openedx-woocommerce-plugin-settings.php
@@ -85,6 +85,9 @@ class Openedx_Woocommerce_Plugin_Settings {
 	 * @return void
 	 */
 	public function openedx_settings_init() {
+
+		// General settings section.
+
 		add_settings_section(
 			'openedx-settings-section',
 			'',
@@ -124,6 +127,33 @@ class Openedx_Woocommerce_Plugin_Settings {
 			'openedx-settings-section'
 		);
 
+		// Advanced settings section.
+
+		add_settings_section(
+			'openedx-advanced-settings-section',
+			'',
+			array( $this, 'openedx_advanced_settings_section_callback' ),
+			'openedx-settings'
+		);
+
+		add_settings_field(
+			'openedx-use-force',
+			'Use force',
+			array( $this, 'openedx_use_force' ),
+			'openedx-settings',
+			'openedx-advanced-settings-section'
+		);
+
+		add_settings_field(
+			'openedx-use-allowed',
+			'Use enrollment allowed',
+			array( $this, 'openedx_use_allowed' ),
+			'openedx-settings',
+			'openedx-advanced-settings-section'
+		);
+
+		// Register general settings.
+
 		register_setting(
 			'openedx-settings-group',
 			'openedx-domain',
@@ -146,6 +176,20 @@ class Openedx_Woocommerce_Plugin_Settings {
 			'openedx-settings-group',
 			'openedx-jwt-token',
 			'sanitize_text_field'
+		);
+
+		// Register advanced settings.
+
+		register_setting(
+			'openedx-settings-group',
+			'openedx-use-force',
+			array( $this, 'sanitize_checkbox' ),
+		);
+
+		register_setting(
+			'openedx-settings-group',
+			'openedx-use-allowed',
+			array( $this, 'sanitize_checkbox' ),
 		);
 
 		if ( isset( $_POST['generate_new_token'] ) ) {
@@ -203,6 +247,62 @@ class Openedx_Woocommerce_Plugin_Settings {
 		}
 	}
 
+	/**
+	 * Output the use force setting field.
+	 *
+	 * Retrieves the saved use force value and outputs an input field and description text.
+	 *
+	 * @return void
+	 */
+	public function openedx_use_force() {
+		$value  = get_option( 'openedx-use-force' );
+		$status = '';
+		if ( $value ) {
+			$status = 'checked';
+		} else {
+			$status = '';
+		}
+
+		?>
+			<input type="checkbox" id="openedx-use-force" name="openedx-use-force" <?php echo esc_attr( $status ); ?> />
+			<label for="openedx-use-force"> Always use the "force" flag in every enrollment request. </label>
+		<?php
+	}
+
+	/**
+	 * Output the use allowed setting field.
+	 *
+	 * Retrieves the saved use allowed value and outputs an input field and description text.
+	 *
+	 * @return void
+	 */
+	public function openedx_use_allowed() {
+		$value  = get_option( 'openedx-use-allowed' );
+		$status = '';
+		if ( $value ) {
+			$status = 'checked';
+		} else {
+			$status = '';
+		}
+		?>
+			<input type="checkbox" id="openedx-use-allowed" name="openedx-use-allowed" <?php echo esc_attr( $status ); ?> />
+			<label for="openedx-use-allowed"> Always use the "enrollment allowed" flag in every enrollment request. </label>
+		<?php
+	}
+
+	/**
+	 * Output the sanitized value of use force/allowed setting field.
+	 *
+	 * @param int $value The value of the setting.
+	 * @return true|false
+	 */
+	public function sanitize_checkbox( $value ) {
+		if ( 'on' === $value ) {
+			return true;
+		} else {
+			return false;
+		}
+	}
 
 	/**
 	 * Output the domain settings field.
@@ -314,6 +414,20 @@ class Openedx_Woocommerce_Plugin_Settings {
 	public function openedx_settings_section_callback() {
 		printf(
 			'Configuring the necessary parameters here to establish the connection between this plugin and your Open edX platform. For more information, you can visit the how-to <a href="https://edunext-docs-openedx-woocommerce-plugin.readthedocs-hosted.com/en/latest/how-tos/create_an_openedx_app.html">Create an Open edX Application for the Plugin Settings</a> in the documentation.'
+		);
+	}
+
+	/**
+	 * Output introductory text for the advanced settings section.
+	 *
+	 * @return void
+	 */
+	public function openedx_advanced_settings_section_callback() {
+		?>
+		<h2>Advanced settings</h2>
+		<?php
+		printf(
+			'Here you can configure general aspects of enrollment requests. '
 		);
 	}
 }

--- a/includes/model/class-openedx-woocommerce-plugin-enrollment.php
+++ b/includes/model/class-openedx-woocommerce-plugin-enrollment.php
@@ -340,8 +340,7 @@ class Openedx_Woocommerce_Plugin_Enrollment {
 			$this->update_post( $post_id, 'enrollment-pending' );
 		}
 
-		$enrollment_action		 = $this->check_advanced_settings( $enrollment_action );
-		error_log($enrollment_action);
+		$enrollment_action       = $this->check_advanced_settings( $enrollment_action );
 		$api                     = new Openedx_Woocommerce_Plugin_Api_Calls();
 		$enrollment_api_response = $api->request_handler( $enrollment_data, $enrollment_action );
 		$this->log_manager->create_change_log( $post_id, $old_data, $enrollment_data, $enrollment_action, $enrollment_api_response );
@@ -354,13 +353,20 @@ class Openedx_Woocommerce_Plugin_Enrollment {
 	}
 
 
+	/**
+	 * Check if advanced settings are enabled to use force or allowed enrollment.
+	 *
+	 * @param string $enrollment_action The API action to perform once the wp process is done.
+	 *
+	 * @return string $enrollment_action The API action to perform once the wp process is done.
+	 */
 	public function check_advanced_settings( $enrollment_action ) {
-		$use_force			 = get_option( 'openedx-use-force' );
-		$use_allowed		 = get_option( 'openedx-use-allowed' );
+		$use_force   = get_option( 'openedx-use-force' );
+		$use_allowed = get_option( 'openedx-use-allowed' );
 
 		if ( $use_force && $use_allowed ) {
 			return 'enrollment_allowed_force';
-		} elseif ( $use_force && ! $use_allowed) {
+		} elseif ( $use_force && ! $use_allowed ) {
 			return 'enrollment_force';
 		} elseif ( ! $use_force && $use_allowed ) {
 			return 'enrollment_allowed';

--- a/includes/model/class-openedx-woocommerce-plugin-enrollment.php
+++ b/includes/model/class-openedx-woocommerce-plugin-enrollment.php
@@ -340,6 +340,8 @@ class Openedx_Woocommerce_Plugin_Enrollment {
 			$this->update_post( $post_id, 'enrollment-pending' );
 		}
 
+		$enrollment_action		 = $this->check_advanced_settings( $enrollment_action );
+		error_log($enrollment_action);
 		$api                     = new Openedx_Woocommerce_Plugin_Api_Calls();
 		$enrollment_api_response = $api->request_handler( $enrollment_data, $enrollment_action );
 		$this->log_manager->create_change_log( $post_id, $old_data, $enrollment_data, $enrollment_action, $enrollment_api_response );
@@ -352,6 +354,20 @@ class Openedx_Woocommerce_Plugin_Enrollment {
 	}
 
 
+	public function check_advanced_settings( $enrollment_action ) {
+		$use_force			 = get_option( 'openedx-use-force' );
+		$use_allowed		 = get_option( 'openedx-use-allowed' );
+
+		if ( $use_force && $use_allowed ) {
+			return 'enrollment_allowed_force';
+		} elseif ( $use_force && ! $use_allowed) {
+			return 'enrollment_force';
+		} elseif ( ! $use_force && $use_allowed ) {
+			return 'enrollment_allowed';
+		} else {
+			return $enrollment_action;
+		}
+	}
 	/**
 	 * Check if important enrollment data is empty to stop operation
 	 *


### PR DESCRIPTION
## Description

Now, in the 'Settings' tab of the plugin, you will find a field titled 'Advanced Settings' that allows you to configure whether the program should ALWAYS use 'force' or 'enrollment allowed' in all requests.

## Testing instructions

Pull the branch locally and run the 'composer install' command to install all plugin dependencies and test.

## Additional information

This is how the settings look now:

![image](https://github.com/openedx/openedx-wordpress-ecommerce/assets/52968528/3d93f807-d700-4856-bbea-5828912634e2)


## Checklist for Merge

- [X] Tested in a remote environment
- [ ] Updated documentation N/A
- [ ] Rebased master/main N/A
- [ ] Squashed commits N/A
