### PR TITLE
fix: plugin working on clean installation

### DIFF
--- a/openedx-ecommerce.php
+++ b/openedx-ecommerce.php
@@ -57,13 +57,14 @@ function deactivate_openedx_woocommerce_plugin() {
  */
 function create_enrollment_logs_table() {
 	global $wpdb;
-	$logs_table = wp_cache_get( 'enrollment_logs_req_table', 'db' );
+	$logs_table      = wp_cache_get( 'enrollment_logs_req_table', 'db' );
+	$logs_table_name = $wpdb->prefix . 'enrollment_logs_req_table';
 
 	if ( ! $logs_table ) {
-		if ( $wpdb->get_var( 'SHOW TABLES LIKE enrollment_logs_req_table' ) !== $logs_table ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
+		if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $logs_table ) ) !== $logs_table ) { // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery
 			$charset_collate = $wpdb->get_charset_collate();
 
-			$sql = "CREATE TABLE $logs_table (
+			$sql = "CREATE TABLE $logs_table_name (
 				id INT NOT NULL AUTO_INCREMENT,
 				post_id INT NOT NULL,
 				mod_date DATETIME NOT NULL,


### PR DESCRIPTION
## Description

The issue of creating Enrollment Requests during a clean installation of WordPress and plugin installation was attributed to caching problems and checks when creating the table that holds vital request information in the WordPress database. After further investigation, the following errors were resolved:

  1. **Misuse of $logs_table Variable:** We identified an error where the variable `$logs_table`, obtained from the `wp_cache_get()` function, was incorrectly being used as the table name. This approach is flawed because the function does not return the table name. Using `$logs_table` for creating the table and conducting existence checks resulted in SQL errors.

  2. **Incorrect Variable Usage:** When the table was not found in the cache, SQL was employed to verify its existence in the database using 'SHOW TABLES LIKE.' Unfortunately, an error was made by using the variable `$logs_table` instead of the actual table name in the database.

  3. **Table Creation Error:** In the `CREATE TABLE` statement, we were using the variable `$logs_table`, which did not contain the correct table name to be created. To rectify this, we introduced the variable `$logs_table_name`, which combines the WordPress prefix and the table name.

- **Code Compliance:** These corrections have been made to align the code with WordPress coding best practices.

This commit addresses these issues and improves the overall code reliability.

## Testing instructions

To perform testing, you should bring the code from this branch to your local environment, run the 'composer install' command to fetch the libraries, and carry out a clean WordPress installation. Once you have a clean WordPress setup, use a .zip file containing the code we have in your local environment and install the plugin. Finally, verify its proper functionality.

## Checklist for Merge

- [X] Tested in a remote environment
- [ ] Updated documentation N/A
- [ ] Rebased master/main N/A
- [ ] Squashed commits N/A