### PR TITLE
fix: avoid using the email enrollment endpoint to fix a bug in versions without email support

### DIFF
--- a/includes/model/class-openedx-woocommerce-plugin-api-calls.php
+++ b/includes/model/class-openedx-woocommerce-plugin-api-calls.php
@@ -136,7 +136,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 
 			if ( 'enrollment_process' === $enrollment_action ) {
 
-				$request_with_email_body = $this->get_enrollment_process_body( $enrollment_data, false, $access_token_string, $enrollment_action );
+				$request_with_email_body = $this->get_enrollment_process_body( $enrollment_data, true, $access_token_string, $enrollment_action );
 				return $this->process_enrollment_action( $enrollment_data, $enrollment_action, $access_token_string, $request_with_email_body, self::API_ENROLLMENT, 'POST' );
 
 			} elseif ( 'enrollment_allowed' === $enrollment_action ) {
@@ -150,7 +150,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 				}
 			} elseif ( 'enrollment_force' === $enrollment_action ) {
 
-				$request_with_email_body = $this->get_enrollment_process_body( $enrollment_data, false, $access_token_string, $enrollment_action );
+				$request_with_email_body = $this->get_enrollment_process_body( $enrollment_data, true, $access_token_string, $enrollment_action );
 				return $this->process_enrollment_action( $enrollment_data, $enrollment_action, $access_token_string, $request_with_email_body, self::API_ENROLLMENT, 'POST' );
 			} elseif ( 'enrollment_allowed_force' === $enrollment_action ) {
 
@@ -166,7 +166,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 
 			if ( 'enrollment_process' === $enrollment_action ) {
 
-				$request_with_email_body = $this->get_enrollment_process_body( $enrollment_data, false, $access_token_string, $enrollment_action );
+				$request_with_email_body = $this->get_enrollment_process_body( $enrollment_data, true, $access_token_string, $enrollment_action );
 				return $this->process_enrollment_action( $enrollment_data, $enrollment_action, $access_token_string, $request_with_email_body, self::API_ENROLLMENT, 'POST' );
 
 			} elseif ( 'enrollment_allowed' === $enrollment_action ) {
@@ -180,7 +180,7 @@ class Openedx_Woocommerce_Plugin_Api_Calls {
 				}
 			} elseif ( 'enrollment_force' === $enrollment_action ) {
 
-				$request_with_email_body = $this->get_enrollment_process_body( $enrollment_data, false, $access_token_string, $enrollment_action );
+				$request_with_email_body = $this->get_enrollment_process_body( $enrollment_data, true, $access_token_string, $enrollment_action );
 				return $this->process_enrollment_action( $enrollment_data, $enrollment_action, $access_token_string, $request_with_email_body, self::API_ENROLLMENT, 'POST' );
 			} elseif ( 'enrollment_allowed_force' === $enrollment_action ) {
 


### PR DESCRIPTION
…

<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy. Try to fill out the template well.
-->

## Description

When we add the new endpoint support in #44, we insert a bug. We tried to make an email enrollment, and in the previous version (Palm and Olive), this didn't fail, but we created an enrollment with the JWT token user, which is not the correct behavior.

To fix this, I only changed the second argument in get_enrollment_process_body to use the old form to request (with users). [More info here](https://github.com/openedx/openedx-wordpress-ecommerce/blob/f240dc09e4b14651bb1a78984b4102e408326d04/includes/model/class-openedx-woocommerce-plugin-api-calls.php#L403).

## Testing instructions

Install this plugin and perform enrollment requests in different versions of Open edX.

Check if you can enroll users and if you can perform course enrollments allowed.

## Additional information
### Without this change (The bug)
Screenshot of performing an enrollment with a user (Olmo version) - we perform this action with a user, and the plugin uses another user (the JWT token user).
![Screenshot from 2023-11-07 18-47-27](https://github.com/openedx/openedx-wordpress-ecommerce/assets/35668326/44263dcc-b226-4054-bbd2-61ba522cedaf)

### With this change
Screenshot of performing an enrollment with a user (Olmo version)
![image](https://github.com/openedx/openedx-wordpress-ecommerce/assets/35668326/c4b1f5e0-4a8b-40d9-a4fa-bce951165121)

Screenshot of performing an enrollment with a user (Quince version)
![image](https://github.com/openedx/openedx-wordpress-ecommerce/assets/35668326/3cc6bdec-d6b5-4884-aa56-0ffe86972a8b)


Screenshot of trying to enroll someone without an Open edX account without and with the enrollment allowed check, respectively (Quince version)
![image](https://github.com/openedx/openedx-wordpress-ecommerce/assets/35668326/822342fc-c96c-4c58-a44f-a27b452766d3)



## Checklist for Merge

- [x] Tested in a remote environment
- [x] Updated documentation
- [x] Rebased master/main
- [x] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
