### PR TITLE
refactor: improve double dirname and add more documentation of Open edX

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,14 @@ Here are some things you can do with this plugin:
 
 - **Obtain enrollment information:** This requests the Open edX APIs to retrieve the enrollment status of a user in a course.
 
+**Note**
+
+This plugin calls the APIs from <a href="https://github.com/openedx/edx-platform" target="_blank">Open edX Platform</a>.
+
+More information about the API connection can be found in <a href="https://github.com/openedx/openedx-wordpress-ecommerce/blob/main/docs/source/decisions/0002-api-connection.rst" target="_blank">Decisions: API connection</a>.
+
+To learn more, you can visit the <a href="https://openedx.org/terms-of-use/" target="_blank">Open edX Terms of Service</a>.
+
 # Installation
 
 ## Requirements

--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@
 Contributors: felipemontoya, julianrg2, mafermazu
 Tags: openedx, open edx, ecommerce, lms, courses
 Requires at least: 6.3
-Tested up to: 6.3.1
+Tested up to: 6.3
 Requires PHP: 8.0
 Stable tag: 2.0.1
 License: GPLv2 or later
@@ -40,6 +40,14 @@ Below are some links to help you get started with Open edX WooCommerce Plugin:
 
 - <a href="https://edunext-docs-openedx-woocommerce-plugin.readthedocs-hosted.com/en/latest/plugin_quickstart.html" target="_blank">Quick Start Guide</a>
 - <a href="https://edunext-docs-openedx-woocommerce-plugin.readthedocs-hosted.com/en/latest/how-tos/index.html" target="_blank">How-to Guides</a>
+
+**Note**
+
+This plugin calls the APIs from <a href="https://github.com/openedx/edx-platform" target="_blank">Open edX Platform</a>.
+
+More information about the API connection can be found in <a href="https://github.com/openedx/openedx-wordpress-ecommerce/blob/main/docs/source/decisions/0002-api-connection.rst" target="_blank">Decisions: API connection</a>.
+
+To learn more, you can visit the <a href="https://openedx.org/terms-of-use/" target="_blank">Open edX Terms of Service</a>.
 
 == Installation ==
 

--- a/includes/class-openedx-commerce-i18n.php
+++ b/includes/class-openedx-commerce-i18n.php
@@ -38,7 +38,7 @@ class Openedx_Commerce_I18n {
 		load_plugin_textdomain(
 			'openedx-commerce',
 			false,
-			dirname( dirname( plugin_basename( __FILE__ ) ) ) . '/languages/'
+			dirname( plugin_basename( __FILE__ ), 2 ) . '/languages/'
 		);
 	}
 }


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy. Try to fill out the template well.
-->

## Description

This PR:

- Improve double dirname

Pass the $levels parameter to the dirname() call instead of using nested dirname() calls (PHP >= 7.0)
    |       |     (Modernize.FunctionCalls.Dirname.Nested)

- Add more documentation

## Additional information

This changes come from common mistakes in WordPress plugins. Mistakes related:

> Incorrect "Tested up to" parameter (readme file):
> This should be the major version of WordPress that this plugin has been tested on. In the case of new plugins, we require it to be the latest version. This is necessary for plugins to be visible in the repository.
> Example: Tested up to: 6.3
> 
> ...
> 
> Failure to disclose third party or external services (readme file):
> Any usage of third party services, such as connecting to an external API, needs to be documented in the readme file.
> 
> How to document this:
> Clearly explain that your plugin is relying on a third party service and under what circumstances.
> Provide a link to the service.
> Provide a link to the service's terms of use and/or privacy policies.
> There is no specific format for this, but please make sure you provide enough info and links to terms of use / privacy policies.

## Checklist for Merge

- [x] Tested in a remote environment
- [x] Updated documentation
- [x] Rebased master/main
<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
