### PR TITLE
fix: remove the exclusion of NonceVerification in phpcs and fix the issues

### DIFF
--- a/admin/class-openedx-commerce-admin.php
+++ b/admin/class-openedx-commerce-admin.php
@@ -16,7 +16,6 @@ use OpenedXCommerce\model\Openedx_Commerce_Post_Type;
 use OpenedXCommerce\admin\views\Openedx_Commerce_Enrollment_Info_Form;
 use OpenedXCommerce\utils;
 
-$nonce = wp_create_nonce( 'openedx_commerce_admin' );
 
 /**
  * The admin-specific functionality of the plugin.
@@ -245,6 +244,8 @@ class Openedx_Commerce_Admin {
 	public function add_custom_product_fields() {
 
 		global $post;
+
+		$nonce = wp_create_nonce( 'openedx_commerce_admin' );
 
 		echo '<div class="custom_options_group">';
 

--- a/admin/class-openedx-commerce-admin.php
+++ b/admin/class-openedx-commerce-admin.php
@@ -16,6 +16,8 @@ use OpenedXCommerce\model\Openedx_Commerce_Post_Type;
 use OpenedXCommerce\admin\views\Openedx_Commerce_Enrollment_Info_Form;
 use OpenedXCommerce\utils;
 
+$nonce = wp_create_nonce( 'openedx_commerce_admin' );
+
 /**
  * The admin-specific functionality of the plugin.
  *
@@ -231,7 +233,7 @@ class Openedx_Commerce_Admin {
 	 * @return void
 	 */
 	public function save_openedx_option( $post_id ) {
-		$openedx_course = isset( $_POST['is_openedx_course'] ) ? 'yes' : 'no';
+		$openedx_course = isset( $_POST['is_openedx_course'] ) ? 'yes' : 'no';  // phpcs:ignore WordPress.Security.NonceVerification.Missing
 		update_post_meta( $post_id, 'is_openedx_course', $openedx_course );
 	}
 
@@ -245,6 +247,8 @@ class Openedx_Commerce_Admin {
 		global $post;
 
 		echo '<div class="custom_options_group">';
+
+		echo '<input type="hidden" name="openedx_commerce_admin" value="<?php echo esc_attr($nonce); ?>">';
 
 		woocommerce_wp_text_input(
 			array(
@@ -316,6 +320,7 @@ class Openedx_Commerce_Admin {
 			$order_url   = esc_url( admin_url( 'post.php?post=' . intval( $input_value ) . '&action=edit' ) );
 
 			$html_output  = '<td>';
+			$html_output .= '<input type="hidden" name="openedx_commerce_admin" value="<?php echo esc_attr($nonce); ?>">';
 			$html_output .= '<input style="height:30px;" type="text" name="openedx_order_id_input' . esc_attr( $item_id ) . '" value="' . esc_attr( $input_value ) . '" pattern="\d*" />';
 			$html_output .= '<a href="' . $order_url . '" class="button" style="margin-left: 5px; vertical-align: bottom;' . ( $input_value ? '' : 'pointer-events: none; opacity: 0.6;' ) . '">View Request</a>';
 			$html_output .= '</td>';
@@ -365,7 +370,7 @@ class Openedx_Commerce_Admin {
 		$items = wc_get_order( $order_id )->get_items();
 
 		foreach ( $items as $item_id => $item ) {
-			if ( isset( $_POST[ 'openedx_order_id_input' . $item_id ] ) ) {
+			if ( wp_verify_nonce( isset( $_POST[ 'openedx_order_id_input' . $item_id ] ), 'openedx_commerce_admin' ) ) {
 				$input_value = sanitize_text_field( wp_unslash( $_POST[ 'openedx_order_id_input' . $item_id ] ) );
 				update_post_meta( $order_id, 'enrollment_id' . $item_id, $input_value );
 			}
@@ -380,8 +385,8 @@ class Openedx_Commerce_Admin {
 	 * @since    1.1.1
 	 */
 	public function save_custom_product_fields( $post_id ) {
-		$course_id = isset( $_POST['_course_id'] ) ? sanitize_text_field( wp_unslash( $_POST['_course_id'] ) ) : '';
-		$mode      = isset( $_POST['_mode'] ) ? sanitize_text_field( wp_unslash( $_POST['_mode'] ) ) : '';
+		$course_id = isset( $_POST['_course_id'] ) ? wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_course_id'] ) ), 'openedx_commerce_admin' ) : '';
+		$mode      = isset( $_POST['_mode'] ) ? wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_mode'] ) ), 'openedx_commerce_admin' ) : '';
 
 		update_post_meta( $post_id, '_course_id', $course_id );
 		update_post_meta( $post_id, '_mode', $mode );

--- a/admin/class-openedx-commerce-admin.php
+++ b/admin/class-openedx-commerce-admin.php
@@ -232,7 +232,12 @@ class Openedx_Commerce_Admin {
 	 * @return void
 	 */
 	public function save_openedx_option( $post_id ) {
-		$openedx_course = isset( $_POST['is_openedx_course'] ) ? 'yes' : 'no';  // phpcs:ignore WordPress.Security.NonceVerification.Missing
+		if ( ! isset( $_POST['openedx_commerce_custom_product_nonce'] ) ||
+			! wp_verify_nonce( sanitize_key( wp_unslash( $_POST['openedx_commerce_custom_product_nonce'] ) ), 'openedx_commerce_custom_product_nonce' )
+		) {
+			return;
+		}
+		$openedx_course = isset( $_POST['is_openedx_course'] ) ? 'yes' : 'no';
 		update_post_meta( $post_id, 'is_openedx_course', $openedx_course );
 	}
 
@@ -245,11 +250,11 @@ class Openedx_Commerce_Admin {
 
 		global $post;
 
-		$nonce = wp_create_nonce( 'openedx_commerce_admin' );
+		$nonce = wp_create_nonce( 'openedx_commerce_custom_product_nonce' );
 
 		echo '<div class="custom_options_group">';
 
-		echo '<input type="hidden" name="openedx_commerce_admin" value="<?php echo esc_attr($nonce); ?>">';
+		echo '<input type="hidden" name="openedx_commerce_custom_product_nonce" value="' . esc_attr( $nonce ) . '">';
 
 		woocommerce_wp_text_input(
 			array(
@@ -308,6 +313,7 @@ class Openedx_Commerce_Admin {
 
 		// Check if the product has a non-empty "_course_id" metadata.
 		$course_id = '';
+		$nonce     = wp_create_nonce( 'openedx_commerce_order_item_nonce' );
 
 		if ( $product ) {
 			$course_id    = get_post_meta( $product->get_id(), '_course_id', true );
@@ -321,7 +327,7 @@ class Openedx_Commerce_Admin {
 			$order_url   = esc_url( admin_url( 'post.php?post=' . intval( $input_value ) . '&action=edit' ) );
 
 			$html_output  = '<td>';
-			$html_output .= '<input type="hidden" name="openedx_commerce_admin" value="<?php echo esc_attr($nonce); ?>">';
+			$html_output .= '<input type="hidden" name="openedx_commerce_order_item_nonce"  value="' . esc_attr( $nonce ) . '">';
 			$html_output .= '<input style="height:30px;" type="text" name="openedx_order_id_input' . esc_attr( $item_id ) . '" value="' . esc_attr( $input_value ) . '" pattern="\d*" />';
 			$html_output .= '<a href="' . $order_url . '" class="button" style="margin-left: 5px; vertical-align: bottom;' . ( $input_value ? '' : 'pointer-events: none; opacity: 0.6;' ) . '">View Request</a>';
 			$html_output .= '</td>';
@@ -370,8 +376,14 @@ class Openedx_Commerce_Admin {
 
 		$items = wc_get_order( $order_id )->get_items();
 
+		if ( ! isset( $_POST['openedx_commerce_order_item_nonce'] ) ||
+			! wp_verify_nonce( sanitize_key( wp_unslash( $_POST['openedx_commerce_order_item_nonce'] ) ), 'openedx_commerce_order_item_nonce' )
+		) {
+			return;
+		}
+
 		foreach ( $items as $item_id => $item ) {
-			if ( wp_verify_nonce( isset( $_POST[ 'openedx_order_id_input' . $item_id ] ), 'openedx_commerce_admin' ) ) {
+			if ( isset( $_POST[ 'openedx_order_id_input' . $item_id ] ) ) {
 				$input_value = sanitize_text_field( wp_unslash( $_POST[ 'openedx_order_id_input' . $item_id ] ) );
 				update_post_meta( $order_id, 'enrollment_id' . $item_id, $input_value );
 			}
@@ -386,8 +398,13 @@ class Openedx_Commerce_Admin {
 	 * @since    1.1.1
 	 */
 	public function save_custom_product_fields( $post_id ) {
-		$course_id = isset( $_POST['_course_id'] ) ? wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_course_id'] ) ), 'openedx_commerce_admin' ) : '';
-		$mode      = isset( $_POST['_mode'] ) ? wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['_mode'] ) ), 'openedx_commerce_admin' ) : '';
+		if ( ! isset( $_POST['openedx_commerce_custom_product_nonce'] ) ||
+			! wp_verify_nonce( sanitize_key( wp_unslash( $_POST['openedx_commerce_custom_product_nonce'] ) ), 'openedx_commerce_custom_product_nonce' )
+		) {
+			return;
+		}
+		$course_id = isset( $_POST['_course_id'] ) ? sanitize_text_field( wp_unslash( $_POST['_course_id'] ) ) : '';
+		$mode      = isset( $_POST['_mode'] ) ? sanitize_text_field( wp_unslash( $_POST['_mode'] ) ) : '';
 
 		update_post_meta( $post_id, '_course_id', $course_id );
 		update_post_meta( $post_id, '_mode', $mode );

--- a/admin/views/class-openedx-commerce-enrollment-info-form.php
+++ b/admin/views/class-openedx-commerce-enrollment-info-form.php
@@ -17,7 +17,6 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
-$nonce = wp_create_nonce( 'openedx_commerce_enrollment_form' );
 
 /**
  * The Enrollment Info Form code for the form.
@@ -93,6 +92,8 @@ class Openedx_Commerce_Enrollment_Info_Form {
 		if ( ! $course_id && ! $email ) {
 			$openedx_new_enrollment = true;
 		}
+
+		$nonce = wp_create_nonce( 'openedx_commerce_enrollment_form' );
 
 		?>
 		<div id="namediv" class="postbox">

--- a/admin/views/class-openedx-commerce-enrollment-info-form.php
+++ b/admin/views/class-openedx-commerce-enrollment-info-form.php
@@ -17,6 +17,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+$nonce = wp_create_nonce( 'openedx_commerce_enrollment_form' );
+
 /**
  * The Enrollment Info Form code for the form.
  */
@@ -98,6 +100,7 @@ class Openedx_Commerce_Enrollment_Info_Form {
 			<fieldset>
 				<h2 class="">Open edX enrollment request</h2>
 				<input type="hidden" name="openedx_new_enrollment" value="<?php echo wp_kses( $openedx_new_enrollment, array( 'true', 'false' ) ); ?>">
+				<input type="hidden" name="openedx_commerce_enrollment_form" value="<?php echo esc_attr( $nonce ); ?>">
 				<table class="form-table">
 					<tbody>
 						<tr>

--- a/admin/views/class-openedx-commerce-enrollment-info-form.php
+++ b/admin/views/class-openedx-commerce-enrollment-info-form.php
@@ -93,7 +93,7 @@ class Openedx_Commerce_Enrollment_Info_Form {
 			$openedx_new_enrollment = true;
 		}
 
-		$nonce = wp_create_nonce( 'openedx_commerce_enrollment_form' );
+		wp_nonce_field( 'openedx_commerce_enrollment_form', 'openedx_commerce_enrollment_form_nonce' );
 
 		?>
 		<div id="namediv" class="postbox">
@@ -101,7 +101,6 @@ class Openedx_Commerce_Enrollment_Info_Form {
 			<fieldset>
 				<h2 class="">Open edX enrollment request</h2>
 				<input type="hidden" name="openedx_new_enrollment" value="<?php echo wp_kses( $openedx_new_enrollment, array( 'true', 'false' ) ); ?>">
-				<input type="hidden" name="openedx_commerce_enrollment_form" value="<?php echo esc_attr( $nonce ); ?>">
 				<table class="form-table">
 					<tbody>
 						<tr>

--- a/admin/views/class-openedx-commerce-settings.php
+++ b/admin/views/class-openedx-commerce-settings.php
@@ -14,7 +14,6 @@ use OpenedXCommerce\model\Openedx_Commerce_Api_Calls;
 use DateTime;
 use DateInterval;
 
-$nonce = wp_create_nonce( 'openedx_commerce_new_token' );
 
 /**
  * This class allows the user to configure the plugin settings
@@ -189,7 +188,7 @@ class Openedx_Commerce_Settings {
 			$exp_date->add( new DateInterval( 'PT' . $exp_time . 'S' ) );
 			update_option( 'openedx-token-expiration-overlap', $exp_date );
 
-			$nonce = wp_create_nonce( 'token_generated_nonce' );
+			$nonce = wp_create_nonce( 'openedx_commerce_new_token' );
 			update_option( 'openedx-jwt-token', $response_data['access_token'] );
 
 			set_transient( 'openedx_success_message', 'Token generated', 10 );

--- a/admin/views/class-openedx-commerce-settings.php
+++ b/admin/views/class-openedx-commerce-settings.php
@@ -14,6 +14,8 @@ use OpenedXCommerce\model\Openedx_Commerce_Api_Calls;
 use DateTime;
 use DateInterval;
 
+$nonce = wp_create_nonce( 'openedx_commerce_new_token' );
+
 /**
  * This class allows the user to configure the plugin settings
  * focusing on the connection between Open edX platform and the store.
@@ -148,7 +150,7 @@ class Openedx_Commerce_Settings {
 			'sanitize_text_field'
 		);
 
-		if ( isset( $_POST['generate_new_token'] ) ) {
+		if ( wp_verify_nonce( isset( $_POST['generate_new_token'] ), 'openedx_commerce_new_token' ) ) {
 			$this->set_new_token();
 		}
 
@@ -287,6 +289,7 @@ class Openedx_Commerce_Settings {
 		?>
 
 		<div class="openedx-jwt-token-wrapper">
+			<input type="hidden" name="openedx_commerce_new_token" value="<?php echo esc_attr( $nonce ); ?>">
 
 			<input class="setting_input" class="openedx-jwt-token-input" type="text" name="openedx-jwt-token" id="openedx-jwt-token"
 				value="<?php echo esc_attr( $value ); ?>" hidden/>

--- a/admin/views/class-openedx-commerce-settings.php
+++ b/admin/views/class-openedx-commerce-settings.php
@@ -149,7 +149,13 @@ class Openedx_Commerce_Settings {
 			'sanitize_text_field'
 		);
 
-		if ( wp_verify_nonce( isset( $_POST['generate_new_token'] ), 'openedx_commerce_new_token' ) ) {
+		if ( ! isset( $_POST['openedx_commerce_new_token_nonce'] ) ||
+			! wp_verify_nonce( sanitize_key( wp_unslash( $_POST['openedx_commerce_new_token_nonce'] ) ), 'openedx_commerce_token' )
+		) {
+			return;
+		}
+
+		if ( isset( $_POST['generate_new_token'] ) ) {
 			$this->set_new_token();
 		}
 
@@ -188,7 +194,6 @@ class Openedx_Commerce_Settings {
 			$exp_date->add( new DateInterval( 'PT' . $exp_time . 'S' ) );
 			update_option( 'openedx-token-expiration-overlap', $exp_date );
 
-			$nonce = wp_create_nonce( 'openedx_commerce_new_token' );
 			update_option( 'openedx-jwt-token', $response_data['access_token'] );
 
 			set_transient( 'openedx_success_message', 'Token generated', 10 );
@@ -285,10 +290,11 @@ class Openedx_Commerce_Settings {
 			$masked_value = '';
 		}
 
+		wp_nonce_field( 'openedx_commerce_token', 'openedx_commerce_new_token_nonce' );
+
 		?>
 
 		<div class="openedx-jwt-token-wrapper">
-			<input type="hidden" name="openedx_commerce_new_token" value="<?php echo esc_attr( $nonce ); ?>">
 
 			<input class="setting_input" class="openedx-jwt-token-input" type="text" name="openedx-jwt-token" id="openedx-jwt-token"
 				value="<?php echo esc_attr( $value ); ?>" hidden/>

--- a/composer.json
+++ b/composer.json
@@ -7,14 +7,14 @@
 		"ext-dom": "*",
 		"ext-json": "*",
 		"ext-sqlite3": "*",
-		"phpunit/phpunit": "9.*",
+		"phpunit/phpunit": "^9.6",
 		"dealerdirect/phpcodesniffer-composer-installer": "^0.7.2",
-    	"wp-coding-standards/wpcs": "3.0.0"
+    	"wp-coding-standards/wpcs": "^3.0"
 	},
 	"config": {
 	    "allow-plugins": {
-	      "dealerdirect/phpcodesniffer-composer-installer": true
-	    },
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		},
 		"platform": {
 			"php": "8.0.7"
 		}
@@ -39,7 +39,6 @@
 		}
 	},
 	"require": {
-		"phpunit/phpunit": "9.*",
 		"guzzlehttp/guzzle": "^7.7"
 	}
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,78 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "55afd5934dcc2b8e48b73b13765f5c51",
+    "content-hash": "e0c4a96a18262d818bbc9e35751d4bd4",
     "packages": [
-        {
-            "name": "doctrine/instantiator",
-            "version": "1.5.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.1 || ^8.0"
-            },
-            "require-dev": {
-                "doctrine/coding-standard": "^9 || ^11",
-                "ext-pdo": "*",
-                "ext-phar": "*",
-                "phpbench/phpbench": "^0.16 || ^1",
-                "phpstan/phpstan": "^1.4",
-                "phpstan/phpstan-phpunit": "^1",
-                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
-                "vimeo/psalm": "^4.30 || ^5.4"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Marco Pivetta",
-                    "email": "ocramius@gmail.com",
-                    "homepage": "https://ocramius.github.io/"
-                }
-            ],
-            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
-            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
-            "keywords": [
-                "constructor",
-                "instantiate"
-            ],
-            "support": {
-                "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
-            },
-            "funding": [
-                {
-                    "url": "https://www.doctrine-project.org/sponsorship.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://www.patreon.com/phpdoctrine",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2022-12-30T00:15:36+00:00"
-        },
         {
             "name": "guzzlehttp/guzzle",
             "version": "7.8.0",
@@ -402,6 +332,424 @@
             "time": "2023-08-27T10:13:57+00:00"
         },
         {
+            "name": "psr/http-client",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-client.git",
+                "reference": "0955afe48220520692d2d09f7ab7e0f93ffd6a31"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-client/zipball/0955afe48220520692d2d09f7ab7e0f93ffd6a31",
+                "reference": "0955afe48220520692d2d09f7ab7e0f93ffd6a31",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.0 || ^8.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Client\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP clients",
+            "homepage": "https://github.com/php-fig/http-client",
+            "keywords": [
+                "http",
+                "http-client",
+                "psr",
+                "psr-18"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-client/tree/1.0.2"
+            },
+            "time": "2023-04-10T20:12:12+00:00"
+        },
+        {
+            "name": "psr/http-factory",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-factory.git",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
+                "reference": "e616d01114759c4c489f93b099585439f795fe35",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for PSR-7 HTTP message factories",
+            "keywords": [
+                "factory",
+                "http",
+                "message",
+                "psr",
+                "psr-17",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
+            },
+            "time": "2023-04-10T20:10:41+00:00"
+        },
+        {
+            "name": "psr/http-message",
+            "version": "2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-message.git",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Message\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP messages",
+            "homepage": "https://github.com/php-fig/http-message",
+            "keywords": [
+                "http",
+                "http-message",
+                "psr",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-message/tree/2.0"
+            },
+            "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "ralouphie/getallheaders",
+            "version": "3.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/ralouphie/getallheaders.git",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
+                "reference": "120b605dfeb996808c31b6477290a714d356e822",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.1",
+                "phpunit/phpunit": "^5 || ^6.5"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/getallheaders.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ralph Khattar",
+                    "email": "ralph.khattar@gmail.com"
+                }
+            ],
+            "description": "A polyfill for getallheaders.",
+            "support": {
+                "issues": "https://github.com/ralouphie/getallheaders/issues",
+                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
+            },
+            "time": "2019-03-08T08:55:37+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.0-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-01-02T09:55:41+00:00"
+        }
+    ],
+    "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "php-parallel-lint/php-parallel-lint": "^1.3.1",
+                "phpcompatibility/php-compatibility": "^9.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcbf",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2022-02-04T12:51:07+00:00"
+        },
+        {
+            "name": "doctrine/instantiator",
+            "version": "1.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/instantiator.git",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^11",
+                "ext-pdo": "*",
+                "ext-phar": "*",
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.30 || ^5.4"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Instantiator\\": "src/Doctrine/Instantiator/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Marco Pivetta",
+                    "email": "ocramius@gmail.com",
+                    "homepage": "https://ocramius.github.io/"
+                }
+            ],
+            "description": "A small, lightweight utility to instantiate objects in PHP without invoking their constructors",
+            "homepage": "https://www.doctrine-project.org/projects/instantiator.html",
+            "keywords": [
+                "constructor",
+                "instantiate"
+            ],
+            "support": {
+                "issues": "https://github.com/doctrine/instantiator/issues",
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.doctrine-project.org/sponsorship.html",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.patreon.com/phpdoctrine",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/doctrine%2Finstantiator",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-12-30T00:15:36+00:00"
+        },
+        {
             "name": "myclabs/deep-copy",
             "version": "1.11.1",
             "source": {
@@ -626,6 +974,172 @@
                 "source": "https://github.com/phar-io/version/tree/3.2.1"
             },
             "time": "2022-02-21T01:04:05+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsextra",
+            "version": "1.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
+                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
+                "reference": "11d387c6642b6e4acaf0bd9bf5203b8cca1ec489",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.4",
+                "phpcsstandards/phpcsutils": "^1.0.9",
+                "squizlabs/php_codesniffer": "^3.8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "phpcsstandards/phpcsdevtools": "^1.2.1",
+                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
+                }
+            ],
+            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSExtra/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-08T16:49:07+00:00"
+        },
+        {
+            "name": "phpcsstandards/phpcsutils",
+            "version": "1.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
+                "reference": "908247bc65010c7b7541a9551e002db12e9dae70"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/908247bc65010c7b7541a9551e002db12e9dae70",
+                "reference": "908247bc65010c7b7541a9551e002db12e9dae70",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
+                "php": ">=5.4",
+                "squizlabs/php_codesniffer": "^3.8.0 || 4.0.x-dev@dev"
+            },
+            "require-dev": {
+                "ext-filter": "*",
+                "php-parallel-lint/php-console-highlighter": "^1.0",
+                "php-parallel-lint/php-parallel-lint": "^1.3.2",
+                "phpcsstandards/phpcsdevcs": "^1.1.6",
+                "yoast/phpunit-polyfills": "^1.1.0 || ^2.0.0"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-stable": "1.x-dev",
+                    "dev-develop": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "classmap": [
+                    "PHPCSUtils/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "LGPL-3.0-or-later"
+            ],
+            "authors": [
+                {
+                    "name": "Juliette Reinders Folmer",
+                    "homepage": "https://github.com/jrfnl",
+                    "role": "lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
+                }
+            ],
+            "description": "A suite of utility functions for use with PHP_CodeSniffer",
+            "homepage": "https://phpcsutils.com/",
+            "keywords": [
+                "PHP_CodeSniffer",
+                "phpcbf",
+                "phpcodesniffer-standard",
+                "phpcs",
+                "phpcs3",
+                "standards",
+                "static analysis",
+                "tokens",
+                "utility"
+            ],
+            "support": {
+                "docs": "https://phpcsutils.com/",
+                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
+                "security": "https://github.com/PHPCSStandards/PHPCSUtils/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/PHPCSStandards",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
+                }
+            ],
+            "time": "2023-12-08T14:50:00+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1048,210 +1562,6 @@
                 }
             ],
             "time": "2023-08-19T07:10:56+00:00"
-        },
-        {
-            "name": "psr/http-client",
-            "version": "1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-client.git",
-                "reference": "0955afe48220520692d2d09f7ab7e0f93ffd6a31"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-client/zipball/0955afe48220520692d2d09f7ab7e0f93ffd6a31",
-                "reference": "0955afe48220520692d2d09f7ab7e0f93ffd6a31",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.0 || ^8.0",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Client\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP clients",
-            "homepage": "https://github.com/php-fig/http-client",
-            "keywords": [
-                "http",
-                "http-client",
-                "psr",
-                "psr-18"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-client/tree/1.0.2"
-            },
-            "time": "2023-04-10T20:12:12+00:00"
-        },
-        {
-            "name": "psr/http-factory",
-            "version": "1.0.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-factory.git",
-                "reference": "e616d01114759c4c489f93b099585439f795fe35"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-factory/zipball/e616d01114759c4c489f93b099585439f795fe35",
-                "reference": "e616d01114759c4c489f93b099585439f795fe35",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.0.0",
-                "psr/http-message": "^1.0 || ^2.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interfaces for PSR-7 HTTP message factories",
-            "keywords": [
-                "factory",
-                "http",
-                "message",
-                "psr",
-                "psr-17",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-factory/tree/1.0.2"
-            },
-            "time": "2023-04-10T20:10:41+00:00"
-        },
-        {
-            "name": "psr/http-message",
-            "version": "2.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/php-fig/http-message.git",
-                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/http-message/zipball/402d35bcb92c70c026d1a6a9883f06b2ead23d71",
-                "reference": "402d35bcb92c70c026d1a6a9883f06b2ead23d71",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^7.2 || ^8.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.0.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Psr\\Http\\Message\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "PHP-FIG",
-                    "homepage": "https://www.php-fig.org/"
-                }
-            ],
-            "description": "Common interface for HTTP messages",
-            "homepage": "https://github.com/php-fig/http-message",
-            "keywords": [
-                "http",
-                "http-message",
-                "psr",
-                "psr-7",
-                "request",
-                "response"
-            ],
-            "support": {
-                "source": "https://github.com/php-fig/http-message/tree/2.0"
-            },
-            "time": "2023-04-04T09:54:51+00:00"
-        },
-        {
-            "name": "ralouphie/getallheaders",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/ralouphie/getallheaders.git",
-                "reference": "120b605dfeb996808c31b6477290a714d356e822"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/ralouphie/getallheaders/zipball/120b605dfeb996808c31b6477290a714d356e822",
-                "reference": "120b605dfeb996808c31b6477290a714d356e822",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.6"
-            },
-            "require-dev": {
-                "php-coveralls/php-coveralls": "^2.1",
-                "phpunit/phpunit": "^5 || ^6.5"
-            },
-            "type": "library",
-            "autoload": {
-                "files": [
-                    "src/getallheaders.php"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ralph Khattar",
-                    "email": "ralph.khattar@gmail.com"
-                }
-            ],
-            "description": "A polyfill for getallheaders.",
-            "support": {
-                "issues": "https://github.com/ralouphie/getallheaders/issues",
-                "source": "https://github.com/ralouphie/getallheaders/tree/develop"
-            },
-            "time": "2019-03-08T08:55:37+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2218,71 +2528,84 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
-            "name": "symfony/deprecation-contracts",
-            "version": "v3.0.2",
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.8.1",
             "source": {
                 "type": "git",
-                "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c"
+                "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
-                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/14f5fff1e64118595db5408e946f3a22c75807f7",
+                "reference": "14f5fff1e64118595db5408e946f3a22c75807f7",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0.2"
+                "ext-simplexml": "*",
+                "ext-tokenizer": "*",
+                "ext-xmlwriter": "*",
+                "php": ">=5.4.0"
             },
+            "require-dev": {
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0 || ^8.0 || ^9.3.4"
+            },
+            "bin": [
+                "bin/phpcbf",
+                "bin/phpcs"
+            ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
-                },
-                "thanks": {
-                    "name": "symfony/contracts",
-                    "url": "https://github.com/symfony/contracts"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "files": [
-                    "function.php"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
-                "MIT"
+                "BSD-3-Clause"
             ],
             "authors": [
                 {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
+                    "name": "Greg Sherwood",
+                    "role": "Former lead"
                 },
                 {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
+                    "name": "Juliette Reinders Folmer",
+                    "role": "Current lead"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer/graphs/contributors"
                 }
             ],
-            "description": "A generic function and convention to trigger deprecation notices",
-            "homepage": "https://symfony.com",
+            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
+            "homepage": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+            "keywords": [
+                "phpcs",
+                "standards",
+                "static analysis"
+            ],
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.2"
+                "issues": "https://github.com/PHPCSStandards/PHP_CodeSniffer/issues",
+                "security": "https://github.com/PHPCSStandards/PHP_CodeSniffer/security/policy",
+                "source": "https://github.com/PHPCSStandards/PHP_CodeSniffer",
+                "wiki": "https://github.com/PHPCSStandards/PHP_CodeSniffer/wiki"
             },
             "funding": [
                 {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
+                    "url": "https://github.com/PHPCSStandards",
                     "type": "github"
                 },
                 {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
+                    "url": "https://github.com/jrfnl",
+                    "type": "github"
+                },
+                {
+                    "url": "https://opencollective.com/php_codesniffer",
+                    "type": "open_collective"
                 }
             ],
-            "time": "2022-01-02T09:55:41+00:00"
+            "time": "2024-01-11T20:47:48+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -2333,289 +2656,19 @@
                 }
             ],
             "time": "2021-07-28T10:34:58+00:00"
-        }
-    ],
-    "packages-dev": [
-        {
-            "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v0.7.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
-                "reference": "1c968e542d8843d7cd71de3c5c9c3ff3ad71a1db",
-                "shasum": ""
-            },
-            "require": {
-                "composer-plugin-api": "^1.0 || ^2.0",
-                "php": ">=5.3",
-                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
-            },
-            "require-dev": {
-                "composer/composer": "*",
-                "php-parallel-lint/php-parallel-lint": "^1.3.1",
-                "phpcompatibility/php-compatibility": "^9.0"
-            },
-            "type": "composer-plugin",
-            "extra": {
-                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
-            },
-            "autoload": {
-                "psr-4": {
-                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Franck Nijhof",
-                    "email": "franck.nijhof@dealerdirect.com",
-                    "homepage": "http://www.frenck.nl",
-                    "role": "Developer / IT Manager"
-                },
-                {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer/graphs/contributors"
-                }
-            ],
-            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
-            "homepage": "http://www.dealerdirect.com",
-            "keywords": [
-                "PHPCodeSniffer",
-                "PHP_CodeSniffer",
-                "code quality",
-                "codesniffer",
-                "composer",
-                "installer",
-                "phpcbf",
-                "phpcs",
-                "plugin",
-                "qa",
-                "quality",
-                "standard",
-                "standards",
-                "style guide",
-                "stylecheck",
-                "tests"
-            ],
-            "support": {
-                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
-                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
-            },
-            "time": "2022-02-04T12:51:07+00:00"
-        },
-        {
-            "name": "phpcsstandards/phpcsextra",
-            "version": "1.1.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/PHPCSStandards/PHPCSExtra.git",
-                "reference": "98bcdbacbda14b1db85f710b1853125726795bbc"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSExtra/zipball/98bcdbacbda14b1db85f710b1853125726795bbc",
-                "reference": "98bcdbacbda14b1db85f710b1853125726795bbc",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=5.4",
-                "phpcsstandards/phpcsutils": "^1.0.8",
-                "squizlabs/php_codesniffer": "^3.7.1"
-            },
-            "require-dev": {
-                "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
-                "phpcsstandards/phpcsdevcs": "^1.1.6",
-                "phpcsstandards/phpcsdevtools": "^1.2.1",
-                "phpunit/phpunit": "^4.5 || ^5.0 || ^6.0 || ^7.0"
-            },
-            "type": "phpcodesniffer-standard",
-            "extra": {
-                "branch-alias": {
-                    "dev-stable": "1.x-dev",
-                    "dev-develop": "1.x-dev"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Juliette Reinders Folmer",
-                    "homepage": "https://github.com/jrfnl",
-                    "role": "lead"
-                },
-                {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/PHPCSStandards/PHPCSExtra/graphs/contributors"
-                }
-            ],
-            "description": "A collection of sniffs and standards for use with PHP_CodeSniffer.",
-            "keywords": [
-                "PHP_CodeSniffer",
-                "phpcbf",
-                "phpcodesniffer-standard",
-                "phpcs",
-                "standards",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/PHPCSStandards/PHPCSExtra/issues",
-                "source": "https://github.com/PHPCSStandards/PHPCSExtra"
-            },
-            "time": "2023-08-26T04:46:45+00:00"
-        },
-        {
-            "name": "phpcsstandards/phpcsutils",
-            "version": "1.0.8",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/PHPCSStandards/PHPCSUtils.git",
-                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHPCSUtils/zipball/69465cab9d12454e5e7767b9041af0cd8cd13be7",
-                "reference": "69465cab9d12454e5e7767b9041af0cd8cd13be7",
-                "shasum": ""
-            },
-            "require": {
-                "dealerdirect/phpcodesniffer-composer-installer": "^0.4.1 || ^0.5 || ^0.6.2 || ^0.7 || ^1.0",
-                "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^3.7.1 || 4.0.x-dev@dev"
-            },
-            "require-dev": {
-                "ext-filter": "*",
-                "php-parallel-lint/php-console-highlighter": "^1.0",
-                "php-parallel-lint/php-parallel-lint": "^1.3.2",
-                "phpcsstandards/phpcsdevcs": "^1.1.6",
-                "yoast/phpunit-polyfills": "^1.0.5 || ^2.0.0"
-            },
-            "type": "phpcodesniffer-standard",
-            "extra": {
-                "branch-alias": {
-                    "dev-stable": "1.x-dev",
-                    "dev-develop": "1.x-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "PHPCSUtils/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "LGPL-3.0-or-later"
-            ],
-            "authors": [
-                {
-                    "name": "Juliette Reinders Folmer",
-                    "homepage": "https://github.com/jrfnl",
-                    "role": "lead"
-                },
-                {
-                    "name": "Contributors",
-                    "homepage": "https://github.com/PHPCSStandards/PHPCSUtils/graphs/contributors"
-                }
-            ],
-            "description": "A suite of utility functions for use with PHP_CodeSniffer",
-            "homepage": "https://phpcsutils.com/",
-            "keywords": [
-                "PHP_CodeSniffer",
-                "phpcbf",
-                "phpcodesniffer-standard",
-                "phpcs",
-                "phpcs3",
-                "standards",
-                "static analysis",
-                "tokens",
-                "utility"
-            ],
-            "support": {
-                "docs": "https://phpcsutils.com/",
-                "issues": "https://github.com/PHPCSStandards/PHPCSUtils/issues",
-                "source": "https://github.com/PHPCSStandards/PHPCSUtils"
-            },
-            "time": "2023-07-16T21:39:41+00:00"
-        },
-        {
-            "name": "squizlabs/php_codesniffer",
-            "version": "3.7.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ed8e00df0a83aa96acf703f8c2979ff33341f879",
-                "reference": "ed8e00df0a83aa96acf703f8c2979ff33341f879",
-                "shasum": ""
-            },
-            "require": {
-                "ext-simplexml": "*",
-                "ext-tokenizer": "*",
-                "ext-xmlwriter": "*",
-                "php": ">=5.4.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
-            },
-            "bin": [
-                "bin/phpcs",
-                "bin/phpcbf"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.x-dev"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
-                {
-                    "name": "Greg Sherwood",
-                    "role": "lead"
-                }
-            ],
-            "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
-            "keywords": [
-                "phpcs",
-                "standards",
-                "static analysis"
-            ],
-            "support": {
-                "issues": "https://github.com/squizlabs/PHP_CodeSniffer/issues",
-                "source": "https://github.com/squizlabs/PHP_CodeSniffer",
-                "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
-            },
-            "time": "2023-02-22T23:07:41+00:00"
         },
         {
             "name": "wp-coding-standards/wpcs",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/WordPress/WordPress-Coding-Standards.git",
-                "reference": "bb792cb331472b82c5d7f28fb9b8ec2d20f68826"
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/bb792cb331472b82c5d7f28fb9b8ec2d20f68826",
-                "reference": "bb792cb331472b82c5d7f28fb9b8ec2d20f68826",
+                "url": "https://api.github.com/repos/WordPress/WordPress-Coding-Standards/zipball/b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
+                "reference": "b4caf9689f1a0e4a4c632679a44e638c1c67aff1",
                 "shasum": ""
             },
             "require": {
@@ -2662,7 +2715,13 @@
                 "source": "https://github.com/WordPress/WordPress-Coding-Standards",
                 "wiki": "https://github.com/WordPress/WordPress-Coding-Standards/wiki"
             },
-            "time": "2023-08-21T14:28:38+00:00"
+            "funding": [
+                {
+                    "url": "https://opencollective.com/thewpcc/contribute/wp-php-63406",
+                    "type": "custom"
+                }
+            ],
+            "time": "2023-09-14T07:06:09+00:00"
         }
     ],
     "aliases": [],
@@ -2680,5 +2739,5 @@
     "platform-overrides": {
         "php": "8.0.7"
     },
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/includes/class-openedx-commerce.php
+++ b/includes/class-openedx-commerce.php
@@ -232,7 +232,7 @@ class Openedx_Commerce {
 		// Redirection from enrollment to order and enrollment to order.
 		$this->loader->add_filter( 'woocommerce_admin_order_item_headers', $plugin_admin, 'add_custom_column_order_items' );
 		$this->loader->add_action( 'woocommerce_admin_order_item_values', $plugin_admin, 'add_admin_order_item_values', 10, 3 );
-		$this->loader->add_action( 'save_post_shop_order', $plugin_admin, 'save_order_meta_data' );
+		$this->loader->add_action( 'woocommerce_update_order', $plugin_admin, 'save_order_meta_data' );
 		$this->loader->add_action(
 			'woocommerce_product_options_general_product_data',
 			$plugin_admin,

--- a/includes/model/class-openedx-commerce-enrollment.php
+++ b/includes/model/class-openedx-commerce-enrollment.php
@@ -232,31 +232,31 @@ class Openedx_Commerce_Enrollment {
 		$enrollment_action = '';
 
 		if ( isset( $_POST['openedx_enrollment_course_id'] ) ) {
-			$enrollment_arr['openedx_enrollment_course_id'] = sanitize_text_field( wp_unslash( $_POST['openedx_enrollment_course_id'] ) );
+			$enrollment_arr['openedx_enrollment_course_id'] = wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['openedx_enrollment_course_id'] ) ), 'openedx_commerce_enrollment_form' );
 		} else {
 			$enrollment_arr['openedx_enrollment_course_id'] = sanitize_text_field( wp_unslash( '' ) );
 		}
 
 		if ( isset( $_POST['openedx_enrollment_email'] ) ) {
-			$enrollment_arr['openedx_enrollment_email'] = sanitize_text_field( wp_unslash( $_POST['openedx_enrollment_email'] ) );
+			$enrollment_arr['openedx_enrollment_email'] = wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['openedx_enrollment_email'] ) ), 'openedx_commerce_enrollment_form' );
 		} else {
 			$enrollment_arr['openedx_enrollment_email'] = sanitize_text_field( wp_unslash( '' ) );
 		}
 
 		if ( isset( $_POST['openedx_enrollment_mode'] ) ) {
-			$enrollment_arr['openedx_enrollment_mode'] = sanitize_text_field( wp_unslash( $_POST['openedx_enrollment_mode'] ) );
+			$enrollment_arr['openedx_enrollment_mode'] = wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['openedx_enrollment_mode'] ) ), 'openedx_commerce_enrollment_form' );
 		} else {
 			$enrollment_arr['openedx_enrollment_mode'] = sanitize_text_field( wp_unslash( '' ) );
 		}
 
 		if ( isset( $_POST['openedx_enrollment_request_type'] ) ) {
-			$enrollment_arr['openedx_enrollment_request_type'] = sanitize_text_field( wp_unslash( $_POST['openedx_enrollment_request_type'] ) );
+			$enrollment_arr['openedx_enrollment_request_type'] = wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['openedx_enrollment_request_type'] ) ), 'openedx_commerce_enrollment_form' );
 		} else {
 			$enrollment_arr['openedx_enrollment_request_type'] = sanitize_text_field( wp_unslash( '' ) );
 		}
 
 		if ( isset( $_POST['openedx_enrollment_order_id'] ) ) {
-			$enrollment_arr['openedx_enrollment_order_id'] = sanitize_text_field( wp_unslash( $_POST['openedx_enrollment_order_id'] ) );
+			$enrollment_arr['openedx_enrollment_order_id'] = wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['openedx_enrollment_order_id'] ) ), 'openedx_commerce_enrollment_form' );
 		} else {
 			$enrollment_arr['openedx_enrollment_order_id'] = sanitize_text_field( wp_unslash( '' ) );
 		}

--- a/includes/model/class-openedx-commerce-enrollment.php
+++ b/includes/model/class-openedx-commerce-enrollment.php
@@ -231,32 +231,38 @@ class Openedx_Commerce_Enrollment {
 		$enrollment_arr    = array();
 		$enrollment_action = '';
 
+		if ( ! isset( $_POST['openedx_commerce_enrollment_form_nonce'] ) ||
+			! wp_verify_nonce( sanitize_key( wp_unslash( $_POST['openedx_commerce_enrollment_form_nonce'] ) ), 'openedx_commerce_enrollment_form' )
+		) {
+			return;
+		}
+
 		if ( isset( $_POST['openedx_enrollment_course_id'] ) ) {
-			$enrollment_arr['openedx_enrollment_course_id'] = wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['openedx_enrollment_course_id'] ) ), 'openedx_commerce_enrollment_form' );
+			$enrollment_arr['openedx_enrollment_course_id'] = sanitize_text_field( wp_unslash( $_POST['openedx_enrollment_course_id'] ) );
 		} else {
 			$enrollment_arr['openedx_enrollment_course_id'] = sanitize_text_field( wp_unslash( '' ) );
 		}
 
 		if ( isset( $_POST['openedx_enrollment_email'] ) ) {
-			$enrollment_arr['openedx_enrollment_email'] = wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['openedx_enrollment_email'] ) ), 'openedx_commerce_enrollment_form' );
+			$enrollment_arr['openedx_enrollment_email'] = sanitize_text_field( wp_unslash( $_POST['openedx_enrollment_email'] ) );
 		} else {
 			$enrollment_arr['openedx_enrollment_email'] = sanitize_text_field( wp_unslash( '' ) );
 		}
 
 		if ( isset( $_POST['openedx_enrollment_mode'] ) ) {
-			$enrollment_arr['openedx_enrollment_mode'] = wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['openedx_enrollment_mode'] ) ), 'openedx_commerce_enrollment_form' );
+			$enrollment_arr['openedx_enrollment_mode'] = sanitize_text_field( wp_unslash( $_POST['openedx_enrollment_mode'] ) );
 		} else {
 			$enrollment_arr['openedx_enrollment_mode'] = sanitize_text_field( wp_unslash( '' ) );
 		}
 
 		if ( isset( $_POST['openedx_enrollment_request_type'] ) ) {
-			$enrollment_arr['openedx_enrollment_request_type'] = wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['openedx_enrollment_request_type'] ) ), 'openedx_commerce_enrollment_form' );
+			$enrollment_arr['openedx_enrollment_request_type'] = sanitize_text_field( wp_unslash( $_POST['openedx_enrollment_request_type'] ) );
 		} else {
 			$enrollment_arr['openedx_enrollment_request_type'] = sanitize_text_field( wp_unslash( '' ) );
 		}
 
 		if ( isset( $_POST['openedx_enrollment_order_id'] ) ) {
-			$enrollment_arr['openedx_enrollment_order_id'] = wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['openedx_enrollment_order_id'] ) ), 'openedx_commerce_enrollment_form' );
+			$enrollment_arr['openedx_enrollment_order_id'] = sanitize_text_field( wp_unslash( $_POST['openedx_enrollment_order_id'] ) );
 		} else {
 			$enrollment_arr['openedx_enrollment_order_id'] = sanitize_text_field( wp_unslash( '' ) );
 		}

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -24,8 +24,4 @@
         </properties>
     </rule>
 
-    <rule ref="Generic.Arrays.DisallowLongArraySyntax">
-        <exclude name="Generic.Arrays.DisallowLongArraySyntax.Found"/>
-        <exclude name="WordPress.Security.NonceVerification.Missing"/>
-    </rule>
 </ruleset>


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy. Try to fill out the template well.
-->

## Description

This PR:
- Adds [nonces](https://developer.wordpress.org/apis/security/nonces/) in the forms of our plugin (settings, enrollment, product and order).
- Removes the exclusion of the **WordPress.Security.NonceVerification.Missing**  alert.
- Changes the action `save_post_shop_order` to `woocommerce_update_order`.

## Testing instructions

- **Check the tests are passing:** To know if we are following the WordPress standards without avoiding alerts.
- **Check if the plugin works as expected in WordPress:** Principally the workflows
    - Save and update the plugin settings ([Reference image](https://github.com/openedx/openedx-wordpress-ecommerce/blob/main/docs/source/_images/how-tos/create_an_openedx_app/openedx-sync-plugin-settings.png))
    - Create or edit a manual enrollment. ([Reference](https://github.com/openedx/openedx-wordpress-ecommerce/blob/main/docs/source/how-tos/create_enrollment_requests_manually.rst))
    - Create or edit an Open edX course product ([Reference](https://github.com/openedx/openedx-wordpress-ecommerce/blob/main/docs/source/how-tos/create_openedx_course_wordpress.rst))
    - Create or edit a WooCommerce Order with an Open edX course product and change the Enrollment associated.

The expected result is that the forms are saved correctly (if the nonce_verification fails, the save or update won't store the new information).

Credentials for the stage to test: https://share.1password.com/s#Pu505pb8w5wyFnHuHhvHBg4K1B5VIHk69kK0O-mCy9s

## Additional information

- This change favors publishing this plugin in the WordPress org and following the WordPress PHPCS standards.
- I changed `save_post_shop_order` to `woocommerce_update_order` because the first one was preventing me from saving the order extra information. 

**More references related:**

- [Nonces](https://developer.wordpress.org/apis/security/nonces/)
- [Understand and use WordPress Nonces](https://developer.wordpress.org/news/2023/08/01/understand-and-use-wordpress-nonces-properly/)
- [Hooks WooCommerce](https://woocommerce.github.io/code-reference/hooks/hooks.html)
- [woocommerce_update_order](https://woocommerce.github.io/code-reference/files/woocommerce-includes-data-stores-class-wc-order-data-store-cpt.html#source-view.196)

## Checklist for Merge

- [x] Tested in a remote environment (I tested all the workflows mentioned and the full shopping workflow)
- [x] Updated documentation
- [x] Rebased master/main
- [x] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
