### PR TITLE
fix: internationalization and slug text domain congruence

### DIFF
--- a/admin/views/class-openedx-commerce-enrollment-info-form.php
+++ b/admin/views/class-openedx-commerce-enrollment-info-form.php
@@ -116,7 +116,7 @@ class Openedx_Commerce_Enrollment_Info_Form {
 								?>
 								>
 								<span class="openedx-tooltip-icon">?</span>
-								<span class="openedx-tooltip-text"><?php esc_html_e( 'The id of the course to be used for the enroll, e.g. course-v1:edX+DemoX+Demo_Course.', 'wp-openedx-commerce' ); ?></span>
+								<span class="openedx-tooltip-text"><?php esc_html_e( 'The id of the course to be used for the enroll, e.g. course-v1:edX+DemoX+Demo_Course.', 'openedx-commerce' ); ?></span>
 							</td>
 						</tr>
 						<tr>
@@ -126,8 +126,8 @@ class Openedx_Commerce_Enrollment_Info_Form {
 									<input type="email" id="openedx_enrollment_email" name="openedx_enrollment_email" value="<?php echo esc_attr( $email ); ?>"> 
 								</div>
 								<span class="openedx-tooltip-icon">?</span>
-								<span class="openedx-tooltip-text"><?php esc_html_e( 'The email of the user to be used for the enroll.', 'wp-openedx-commerce' ); ?></span>
-								<button name="enrollment_sync" class="button save_order button-secondary sync_button"><span><?php esc_html_e( 'Read from Open edX', 'wp-openedx-commerce' ); ?></span></button>
+								<span class="openedx-tooltip-text"><?php esc_html_e( 'The email of the user to be used for the enroll.', 'openedx-commerce' ); ?></span>
+								<button name="enrollment_sync" class="button save_order button-secondary sync_button"><span><?php esc_html_e( 'Read from Open edX', 'openedx-commerce' ); ?></span></button>
 							</td>
 						</tr>
 						<tr class="gray_zone first_zone">
@@ -141,7 +141,7 @@ class Openedx_Commerce_Enrollment_Info_Form {
 									<?php endforeach; ?>
 								</select>
 								<span class="openedx-tooltip-icon">?</span>
-								<span class="openedx-tooltip-text"><?php esc_html_e( 'The mode of your enrollment request. Make sure to set a mode that your course has.', 'wp-openedx-commerce' ); ?></span>
+								<span class="openedx-tooltip-text"><?php esc_html_e( 'The mode of your enrollment request. Make sure to set a mode that your course has.', 'openedx-commerce' ); ?></span>
 							</td>
 						</tr>
 
@@ -160,7 +160,7 @@ class Openedx_Commerce_Enrollment_Info_Form {
 									?>
 									>
 									<?php
-									esc_html_e( 'Enroll', 'wp-openedx-commerce' );
+									esc_html_e( 'Enroll', 'openedx-commerce' );
 									?>
 									</option>
 									<option value="unenroll" 
@@ -171,12 +171,12 @@ class Openedx_Commerce_Enrollment_Info_Form {
 									?>
 									>
 									<?php
-									esc_html_e( 'Un-enroll', 'wp-openedx-commerce' );
+									esc_html_e( 'Un-enroll', 'openedx-commerce' );
 									?>
 									</option>
 								</select>
 								<span class="openedx-tooltip-icon">?</span>
-								<span class="openedx-tooltip-text"><?php esc_html_e( 'The type of your request. If you select Enroll, you will create an enrollment, and if you select Un-enroll, you will set a soft unenrollment (enrollment with status inactive).', 'wp-openedx-commerce' ); ?></span>
+								<span class="openedx-tooltip-text"><?php esc_html_e( 'The type of your request. If you select Enroll, you will create an enrollment, and if you select Un-enroll, you will set a soft unenrollment (enrollment with status inactive).', 'openedx-commerce' ); ?></span>
 							</td>
 						</tr>
 						<tr class="gray_zone">
@@ -195,31 +195,31 @@ class Openedx_Commerce_Enrollment_Info_Form {
 									?>
 								</div>
 								<span class="openedx-tooltip-icon">?</span>
-								<span class="openedx-tooltip-text"><?php esc_html_e( 'The id of the order associated with this request.', 'wp-openedx-commerce' ); ?></span>
+								<span class="openedx-tooltip-text"><?php esc_html_e( 'The id of the order associated with this request.', 'openedx-commerce' ); ?></span>
 							</td>
 						</tr>
 
 						<tr class="gray_zone">
 							<td class="checkbox-td">		
 								<input class="action-checkbox" type="checkbox" id="openedx_enrollment_force" name="openedx_enrollment_force" value="openedx_force">
-								<label for="openedx_enrollment_force"><?php esc_html_e( 'Use the "force" flag', 'wp-openedx-commerce' ); ?></label>
+								<label for="openedx_enrollment_force"><?php esc_html_e( 'Use the "force" flag', 'openedx-commerce' ); ?></label>
 								<span class="openedx-tooltip-icon">?</span>
-								<span class="openedx-tooltip-text"><?php esc_html_e( "Disregard the course's enrollment end dates.", 'wp-openedx-commerce' ); ?></span>
+								<span class="openedx-tooltip-text"><?php esc_html_e( "Disregard the course's enrollment end dates.", 'openedx-commerce' ); ?></span>
 							</td>
 							<td>
 								<input class="action-checkbox" type="checkbox" id="openedx_enrollment_allowed" name="openedx_enrollment_allowed" value="openedx_allowed">
-								<label for="openedx_enrollment_allowed"><?php esc_html_e( "Create course enrollment allowed if the user doesn't exist", 'wp-openedx-commerce' ); ?></label>
+								<label for="openedx_enrollment_allowed"><?php esc_html_e( "Create course enrollment allowed if the user doesn't exist", 'openedx-commerce' ); ?></label>
 								<span class="openedx-tooltip-icon">?</span>
-								<span class="openedx-tooltip-text"><?php esc_html_e( 'Creates a register in the table Course Enrollment Allowed if the email we use in the request is not a user in our Open edX platform yet.', 'wp-openedx-commerce' ); ?></span>
+								<span class="openedx-tooltip-text"><?php esc_html_e( 'Creates a register in the table Course Enrollment Allowed if the email we use in the request is not a user in our Open edX platform yet.', 'openedx-commerce' ); ?></span>
 							</td>
 						</tr>
 
 						<tr class="gray_zone">
 							<td class="first">
-								<button name="enrollment_process" class="button save_order button-primary"><span><?php esc_html_e( 'Save and update Open edX', 'wp-openedx-commerce' ); ?></span></button>
+								<button name="enrollment_process" class="button save_order button-primary"><span><?php esc_html_e( 'Save and update Open edX', 'openedx-commerce' ); ?></span></button>
 							</td>
 							<td>
-								<button name="save_no_process" class="button save_order button-secondary"><span><?php esc_html_e( 'Save in WordPress', 'wp-openedx-commerce' ); ?></span></button>
+								<button name="save_no_process" class="button save_order button-secondary"><span><?php esc_html_e( 'Save in WordPress', 'openedx-commerce' ); ?></span></button>
 							</td>
 						</tr>
 					</tbody>

--- a/includes/model/class-openedx-commerce-enrollment.php
+++ b/includes/model/class-openedx-commerce-enrollment.php
@@ -148,7 +148,7 @@ class Openedx_Commerce_Enrollment {
 		register_post_status(
 			'success',
 			array(
-				'label'                     => __( 'success', 'wp-openedx-commerce' ),
+				'label'                     => __( 'success', 'openedx-commerce' ),
 				'public'                    => false,
 				'internal'                  => true,
 				'private'                   => true,
@@ -156,13 +156,13 @@ class Openedx_Commerce_Enrollment {
 				'show_in_admin_all_list'    => true,
 				'show_in_admin_status_list' => true,
 				// translators: %s: number of items.
-				'label_count'               => _n_noop( 'Success <span class="count">(%s)</span>', 'Success <span class="count">(%s)</span>', 'wp-openedx-commerce' ),
+				'label_count'               => _n_noop( 'Success <span class="count">(%s)</span>', 'Success <span class="count">(%s)</span>', 'openedx-commerce' ),
 			)
 		);
 		register_post_status(
 			'no_process',
 			array(
-				'label'                     => __( 'success', 'wp-openedx-commerce' ),
+				'label'                     => __( 'success', 'openedx-commerce' ),
 				'public'                    => false,
 				'internal'                  => true,
 				'private'                   => true,
@@ -170,13 +170,13 @@ class Openedx_Commerce_Enrollment {
 				'show_in_admin_all_list'    => true,
 				'show_in_admin_status_list' => true,
 				// translators: %s: number of items.
-				'label_count'               => _n_noop( 'No process <span class="count">(%s)</span>', 'No process <span class="count">(%s)</span>', 'wp-openedx-commerce' ),
+				'label_count'               => _n_noop( 'No process <span class="count">(%s)</span>', 'No process <span class="count">(%s)</span>', 'openedx-commerce' ),
 			)
 		);
 		register_post_status(
 			'pending',
 			array(
-				'label'                     => __( 'pending', 'wp-openedx-commerce' ),
+				'label'                     => __( 'pending', 'openedx-commerce' ),
 				'public'                    => false,
 				'internal'                  => true,
 				'private'                   => true,
@@ -184,13 +184,13 @@ class Openedx_Commerce_Enrollment {
 				'show_in_admin_all_list'    => true,
 				'show_in_admin_status_list' => true,
 				// translators: %s: number of items.
-				'label_count'               => _n_noop( 'Pending <span class="count">(%s)</span>', 'Pending <span class="count">(%s)</span>', 'wp-openedx-commerce' ),
+				'label_count'               => _n_noop( 'Pending <span class="count">(%s)</span>', 'Pending <span class="count">(%s)</span>', 'openedx-commerce' ),
 			)
 		);
 		register_post_status(
 			'error',
 			array(
-				'label'                     => __( 'error', 'wp-openedx-commerce' ),
+				'label'                     => __( 'error', 'openedx-commerce' ),
 				'public'                    => false,
 				'internal'                  => true,
 				'private'                   => true,
@@ -198,7 +198,7 @@ class Openedx_Commerce_Enrollment {
 				'show_in_admin_all_list'    => true,
 				'show_in_admin_status_list' => true,
 				// translators: %s: number of items.
-				'label_count'               => _n_noop( 'Error <span class="count">(%s)</span>', 'Error <span class="count">(%s)</span>', 'wp-openedx-commerce' ),
+				'label_count'               => _n_noop( 'Error <span class="count">(%s)</span>', 'Error <span class="count">(%s)</span>', 'openedx-commerce' ),
 			)
 		);
 	}

--- a/includes/model/class-openedx-commerce-post-type.php
+++ b/includes/model/class-openedx-commerce-post-type.php
@@ -101,7 +101,7 @@ class Openedx_Commerce_Post_Type {
 			'name'               => $this->plural,
 			'singular_name'      => $this->single,
 			'name_admin_bar'     => $this->single,
-			'add_new'            => sprintf( _x( 'Add New', 'openedx-commerce' ), $this->post_type ),
+			'add_new'            => sprintf( _x( 'Add New', 'openedx-commerce', 'openedx-commerce' ), $this->post_type ),
 			// translators: %s: Name of the post type in singular.
 			'add_new_item'       => sprintf( __( 'Add New %s', 'openedx-commerce' ), $this->single ),
 			// translators: %s: Name of the post type in singular.
@@ -119,7 +119,7 @@ class Openedx_Commerce_Post_Type {
 			// translators: %s: Name of the post type in plural.
 			'not_found_in_trash' => sprintf( __( 'No %s Found In Trash', 'openedx-commerce' ), $this->plural ),
 			// translators: %s: Name of the post type in singular.
-			'parent_item_colon'  => sprintf( __( 'Parent %s' ), $this->single ),
+			'parent_item_colon'  => sprintf( __( 'Parent %s', 'openedx-commerce' ), $this->single ),
 			'menu_name'          => $this->plural,
 		);
 

--- a/includes/model/class-openedx-commerce-post-type.php
+++ b/includes/model/class-openedx-commerce-post-type.php
@@ -101,23 +101,23 @@ class Openedx_Commerce_Post_Type {
 			'name'               => $this->plural,
 			'singular_name'      => $this->single,
 			'name_admin_bar'     => $this->single,
-			'add_new'            => _x( 'Add New', $this->post_type, 'wp-openedx-commerce' ), // phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralContext
+			'add_new'            => sprintf( _x( 'Add New', 'openedx-commerce' ), $this->post_type ),
 			// translators: %s: Name of the post type in singular.
-			'add_new_item'       => sprintf( __( 'Add New %s', 'wp-openedx-commerce' ), $this->single ),
+			'add_new_item'       => sprintf( __( 'Add New %s', 'openedx-commerce' ), $this->single ),
 			// translators: %s: Name of the post type in singular.
-			'edit_item'          => sprintf( __( 'Edit %s', 'wp-openedx-commerce' ), $this->single ),
+			'edit_item'          => sprintf( __( 'Edit %s', 'openedx-commerce' ), $this->single ),
 			// translators: %s: Name of the post type in singular.
-			'new_item'           => sprintf( __( 'New %s', 'wp-openedx-commerce' ), $this->single ),
+			'new_item'           => sprintf( __( 'New %s', 'openedx-commerce' ), $this->single ),
 			// translators: %s: Name of the post type in plural.
-			'all_items'          => sprintf( __( 'All %s', 'wp-openedx-commerce' ), $this->plural ),
+			'all_items'          => sprintf( __( 'All %s', 'openedx-commerce' ), $this->plural ),
 			// translators: %s: Name of the post type in singular.
-			'view_item'          => sprintf( __( 'View %s', 'wp-openedx-commerce' ), $this->single ),
+			'view_item'          => sprintf( __( 'View %s', 'openedx-commerce' ), $this->single ),
 			// translators: %s: Name of the post type in plural.
-			'search_items'       => sprintf( __( 'Search %s', 'wp-openedx-commerce' ), $this->plural ),
+			'search_items'       => sprintf( __( 'Search %s', 'openedx-commerce' ), $this->plural ),
 			// translators: %s: Name of the post type in plural.
-			'not_found'          => sprintf( __( 'No %s Found', 'wp-openedx-commerce' ), $this->plural ),
+			'not_found'          => sprintf( __( 'No %s Found', 'openedx-commerce' ), $this->plural ),
 			// translators: %s: Name of the post type in plural.
-			'not_found_in_trash' => sprintf( __( 'No %s Found In Trash', 'wp-openedx-commerce' ), $this->plural ),
+			'not_found_in_trash' => sprintf( __( 'No %s Found In Trash', 'openedx-commerce' ), $this->plural ),
 			// translators: %s: Name of the post type in singular.
 			'parent_item_colon'  => sprintf( __( 'Parent %s' ), $this->single ),
 			'menu_name'          => $this->plural,

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -8,6 +8,7 @@
     <exclude-pattern>./admin/index.php</exclude-pattern>
     <exclude-pattern>./public/index.php</exclude-pattern>
     <exclude-pattern>index.php</exclude-pattern>
+    <exclude-pattern>composer-setup.php</exclude-pattern>
 
     <arg value="sp"/>
     <arg name="basepath" value="./"/>
@@ -16,6 +17,15 @@
     <arg name="parallel" value="8"/>
 
     <rule ref="WordPress">
+    </rule>
+
+    <rule ref="WordPress.WP.I18n">
+        <properties>
+            <property name="text_domain" type="array">
+                <element value="openedx-commerce"/>
+                <element value="woocommerce"/>
+            </property>
+        </properties>
     </rule>
 
     <rule ref="Generic.Files.LineEndings">

--- a/utils/openedx-utils.php
+++ b/utils/openedx-utils.php
@@ -13,11 +13,11 @@ namespace OpenedXCommerce\utils;
  */
 function get_enrollment_options() {
 	return array(
-		'Honor'              => __( 'Honor', 'wp-openedx-commerce' ),
-		'Audit'              => __( 'Audit', 'wp-openedx-commerce' ),
-		'Verified'           => __( 'Verified', 'wp-openedx-commerce' ),
-		'Credit'             => __( 'Credit', 'wp-openedx-commerce' ),
-		'Professional'       => __( 'Professional', 'wp-openedx-commerce' ),
-		'No ID Professional' => __( 'No ID Professional', 'wp-openedx-commerce' ),
+		'Honor'              => __( 'Honor', 'openedx-commerce' ),
+		'Audit'              => __( 'Audit', 'openedx-commerce' ),
+		'Verified'           => __( 'Verified', 'openedx-commerce' ),
+		'Credit'             => __( 'Credit', 'openedx-commerce' ),
+		'Professional'       => __( 'Professional', 'openedx-commerce' ),
+		'No ID Professional' => __( 'No ID Professional', 'openedx-commerce' ),
 	);
 }


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy. Try to fill out the template well.
-->

## Description

This PR:
- Removes the `phpcs:ignore WordPress.WP.I18n.NonSingularStringLiteralContext`
- Changes the text domain used in the internationalization to be congruent with the text domain in the `openedx-commerce.php` header.
- Add a test to check that the text domain is congruent.
- I also excluded composer-setup.php from the phpcs. That is a local file that does not follow the phpcs WordPress standards.

## Testing instructions

- Check if you can still create an Open edX Enrollment Request.
- Check the tests.

## Additional information

I added woocommerce as part of the rules because we added some text in the woocommerce pages.
This change is part of the work to publish the plugin in the WordPress Plugin Directory.

> Internationalization: Don't use variables or defines as text, context or text domain parameters.
> 
> Please do not use variable names for the text, context or text domain portion of a gettext function, all of them NEED to be strings, otherwise they could not be read by the translation parser.
> 
> For example, this is a bad call: esc_html__( 'Translate me.' , $plugin_slug ); , the fix here would be like this esc_html__( 'Translate me.' , 'plugin-slug' );
> 
> This is also wrong: esc_html__( 'Your city is ' . $city . '.' , 'plugin-slug' ); , the fix here would be using a placeholder and change it later using printf , like this:
> print(
> 
>  /* translators: %s: Name of a city */
> 
>  esc_html__( 'Your city is %s.', 'plugin-slug' ),
> 
>  esc_html($city)
> 
> );
> 
> Also have in mind that your text domain has to be the same as your plugin's slug (also known as permalink).
> 
> The text domain also needs to be added to the plugin header. WordPress uses it to internationalize your plugin meta-data even when the plugin is disabled.
> 
> You can read https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains for more information.
> 
> Example(s) from your plugin:
> openedx-commerce/includes/model/class-openedx-commerce-post-type.php:104 _x('Add New', $this->post_type, 'wp-openedx-commerce');

## References
WordPress text domains doc: https://developer.wordpress.org/plugins/internationalization/how-to-internationalize-your-plugin/#text-domains
Example of phpcs.xml file for WordPress Text Domain: https://github.com/WordPress/WordPress-Coding-Standards/blob/develop/phpcs.xml.dist.sample#L105


## Checklist for Merge

- [x] Tested in a remote environment
- [x] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
