### PR TITLE
fix: add naming convention rule

### DIFF
--- a/admin/class-openedx-commerce-admin.php
+++ b/admin/class-openedx-commerce-admin.php
@@ -9,12 +9,12 @@
  * @since      1.0.0
  */
 
-namespace OpenedXCommerce\admin;
+namespace OpenedX_Commerce\admin;
 
-use OpenedXCommerce\model\Openedx_Commerce_Enrollment;
-use OpenedXCommerce\model\Openedx_Commerce_Post_Type;
-use OpenedXCommerce\admin\views\Openedx_Commerce_Enrollment_Info_Form;
-use OpenedXCommerce\utils;
+use OpenedX_Commerce\model\Openedx_Commerce_Enrollment;
+use OpenedX_Commerce\model\Openedx_Commerce_Post_Type;
+use OpenedX_Commerce\admin\views\Openedx_Commerce_Enrollment_Info_Form;
+use OpenedX_Commerce\utils;
 
 
 /**

--- a/admin/views/class-openedx-commerce-enrollment-info-form.php
+++ b/admin/views/class-openedx-commerce-enrollment-info-form.php
@@ -8,10 +8,10 @@
  * @since      1.0.0
  */
 
-namespace OpenedXCommerce\admin\views;
+namespace OpenedX_Commerce\admin\views;
 
-use OpenedXCommerce\model\Openedx_Commerce_Log;
-use OpenedXCommerce\utils;
+use OpenedX_Commerce\model\Openedx_Commerce_Log;
+use OpenedX_Commerce\utils;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/admin/views/class-openedx-commerce-settings.php
+++ b/admin/views/class-openedx-commerce-settings.php
@@ -8,9 +8,9 @@
  * @since      1.6.0
  */
 
-namespace OpenedXCommerce\admin\views;
+namespace OpenedX_Commerce\admin\views;
 
-use OpenedXCommerce\model\Openedx_Commerce_Api_Calls;
+use OpenedX_Commerce\model\Openedx_Commerce_Api_Calls;
 use DateTime;
 use DateInterval;
 

--- a/composer.json
+++ b/composer.json
@@ -29,13 +29,13 @@
 			"test/"
 		],
 		"psr-4": {
-			"OpenedXCommerce\\": "includes/",
-			"OpenedXCommerce\\model\\": "includes/model/",
-			"OpenedXCommerce\\admin\\": "admin/",
-			"OpenedXCommerce\\admin\\views\\": "admin/views/",
-			"OpenedXCommerce\\public\\": "public/",
-			"OpenedXCommerce\\utils\\": "utils/",
-			"OpenedXCommerce\\tests\\": "test/"
+			"OpenedX_Commerce\\": "includes/",
+			"OpenedX_Commerce\\model\\": "includes/model/",
+			"OpenedX_Commerce\\admin\\": "admin/",
+			"OpenedX_Commerce\\admin\\views\\": "admin/views/",
+			"OpenedX_Commerce\\public\\": "public/",
+			"OpenedX_Commerce\\utils\\": "utils/",
+			"OpenedX_Commerce\\tests\\": "test/"
 		}
 	},
 	"require": {

--- a/includes/class-openedx-commerce-activator.php
+++ b/includes/class-openedx-commerce-activator.php
@@ -9,7 +9,7 @@
  * @subpackage Openedx_Commerce/includes
  */
 
-namespace OpenedXCommerce;
+namespace OpenedX_Commerce;
 
 /**
  * Fired during plugin activation.

--- a/includes/class-openedx-commerce-deactivator.php
+++ b/includes/class-openedx-commerce-deactivator.php
@@ -9,7 +9,7 @@
  * @subpackage Openedx_Commerce/includes
  */
 
-namespace OpenedXCommerce;
+namespace OpenedX_Commerce;
 
 /**
  * Fired during plugin deactivation.

--- a/includes/class-openedx-commerce-i18n.php
+++ b/includes/class-openedx-commerce-i18n.php
@@ -12,7 +12,7 @@
  * @subpackage Openedx_Commerce/includes
  */
 
-namespace OpenedXCommerce;
+namespace OpenedX_Commerce;
 
 /**
  * Define the internationalization functionality.

--- a/includes/class-openedx-commerce-loader.php
+++ b/includes/class-openedx-commerce-loader.php
@@ -9,7 +9,7 @@
  * @subpackage Openedx_Commerce/includes
  */
 
-namespace OpenedXCommerce;
+namespace OpenedX_Commerce;
 
 /**
  * Register all actions and filters for the plugin.

--- a/includes/class-openedx-commerce.php
+++ b/includes/class-openedx-commerce.php
@@ -14,12 +14,12 @@
  * @author     eduNEXT <maria.magallanes@edunext.co>
  */
 
-namespace OpenedXCommerce;
+namespace OpenedX_Commerce;
 
-use OpenedXCommerce\admin\Openedx_Commerce_Admin;
-use OpenedXCommerce\public\Openedx_Commerce_Public;
-use OpenedXCommerce\admin\views\Openedx_Commerce_Settings;
-use OpenedXCommerce\model\Openedx_Commerce_Enrollment;
+use OpenedX_Commerce\admin\Openedx_Commerce_Admin;
+use OpenedX_Commerce\public\Openedx_Commerce_Public;
+use OpenedX_Commerce\admin\views\Openedx_Commerce_Settings;
+use OpenedX_Commerce\model\Openedx_Commerce_Enrollment;
 
 /**
  * This class contains the function to register a new custom post type.

--- a/includes/model/class-openedx-commerce-api-calls.php
+++ b/includes/model/class-openedx-commerce-api-calls.php
@@ -9,7 +9,7 @@
  * @since      1.6.0
  */
 
-namespace OpenedXCommerce\model;
+namespace OpenedX_Commerce\model;
 
 require_once plugin_dir_path( dirname( __DIR__ ) ) . 'vendor/autoload.php';
 use DateTime;

--- a/includes/model/class-openedx-commerce-enrollment.php
+++ b/includes/model/class-openedx-commerce-enrollment.php
@@ -10,12 +10,12 @@
  * @since      1.0.0
  */
 
-namespace OpenedXCommerce\model;
+namespace OpenedX_Commerce\model;
 
-use OpenedXCommerce\model\Openedx_Commerce_Log;
-use OpenedXCommerce\Openedx_Commerce;
-use OpenedXCommerce\admin\Openedx_Commerce_Admin;
-use OpenedXCommerce\model\Openedx_Commerce_Api_Calls;
+use OpenedX_Commerce\model\Openedx_Commerce_Log;
+use OpenedX_Commerce\Openedx_Commerce;
+use OpenedX_Commerce\admin\Openedx_Commerce_Admin;
+use OpenedX_Commerce\model\Openedx_Commerce_Api_Calls;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/includes/model/class-openedx-commerce-log.php
+++ b/includes/model/class-openedx-commerce-log.php
@@ -9,7 +9,7 @@
  * @since      1.4.0
  */
 
-namespace OpenedXCommerce\model;
+namespace OpenedX_Commerce\model;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;

--- a/includes/model/class-openedx-commerce-post-type.php
+++ b/includes/model/class-openedx-commerce-post-type.php
@@ -8,7 +8,7 @@
  * @since      1.0.0
  */
 
-namespace OpenedXCommerce\model;
+namespace OpenedX_Commerce\model;
 
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
@@ -124,7 +124,7 @@ class Openedx_Commerce_Post_Type {
 		);
 
 		$args = array(
-			'labels'                => apply_filters( $this->post_type . '_labels', $labels ),
+			'labels'                => apply_filters( "openedx_commerce_{$this->post_type}_labels", $labels ),
 			'description'           => $this->description,
 			'public'                => true,
 			'publicly_queryable'    => true,
@@ -148,6 +148,6 @@ class Openedx_Commerce_Post_Type {
 
 		$args = array_merge( $args, $this->options );
 
-		register_post_type( $this->post_type, apply_filters( $this->post_type . '_register_args', $args, $this->post_type ) );
+		register_post_type( $this->post_type, apply_filters( "openedx_commerce_{$this->post_type}_register_args", $args, $this->post_type ) );
 	}
 }

--- a/openedx-commerce.php
+++ b/openedx-commerce.php
@@ -13,14 +13,14 @@
  * Requires at least: 6.3
  * Requires PHP: 8.0
  *
- * @package           Openedx_Commerce
+ * @package           OpenedX_Commerce
  *
  * @wordpress-plugin
  */
 
-use OpenedXCommerce\Openedx_Commerce_Activator;
-use OpenedXCommerce\Openedx_Commerce_Deactivator;
-use OpenedXCommerce\Openedx_Commerce;
+use OpenedX_Commerce\Openedx_Commerce_Activator;
+use OpenedX_Commerce\Openedx_Commerce_Deactivator;
+use OpenedX_Commerce\Openedx_Commerce;
 
 // If this file is called directly, abort.
 if ( ! defined( 'WPINC' ) ) {
@@ -38,7 +38,7 @@ define( 'OPENEDX_COMMERCE_VERSION', '2.0.2' );
  * The code that runs during plugin activation.
  * This action is documented in includes/class-openedx-commerce-activator.php
  */
-function activate_openedx_commerce_plugin() {
+function openedx_commerce_plugin_activate() {
 	include_once plugin_dir_path( __FILE__ ) . 'includes/class-openedx-commerce-activator.php';
 	Openedx_Commerce_Activator::activate();
 }
@@ -47,7 +47,7 @@ function activate_openedx_commerce_plugin() {
  * The code that runs during plugin deactivation.
  * This action is documented in includes/class-openedx-commerce-deactivator.php
  */
-function deactivate_openedx_commerce_plugin() {
+function openedx_commerce_plugin_deactivate() {
 	include_once plugin_dir_path( __FILE__ ) . 'includes/class-openedx-commerce-deactivator.php';
 	Openedx_Commerce_Deactivator::deactivate();
 }
@@ -55,7 +55,7 @@ function deactivate_openedx_commerce_plugin() {
 /**
  * Create the table for the logs on plugin activation
  */
-function create_enrollment_logs_table() {
+function openedx_commerce_create_enrollment_logs_table() {
 	global $wpdb;
 	$logs_table      = wp_cache_get( 'enrollment_logs_req_table', 'db' );
 	$logs_table_name = $wpdb->prefix . 'enrollment_logs_req_table';
@@ -85,9 +85,9 @@ function create_enrollment_logs_table() {
 	}
 }
 
-register_activation_hook( __FILE__, 'activate_openedx_commerce_plugin' );
-register_activation_hook( __FILE__, 'create_enrollment_logs_table' );
-register_deactivation_hook( __FILE__, 'deactivate_openedx_commerce_plugin' );
+register_activation_hook( __FILE__, 'openedx_commerce_plugin_activate' );
+register_activation_hook( __FILE__, 'openedx_commerce_create_enrollment_logs_table' );
+register_deactivation_hook( __FILE__, 'openedx_commerce_plugin_deactivate' );
 
 /**
  * The core plugin class that is used to define internationalization,
@@ -104,9 +104,9 @@ require plugin_dir_path( __FILE__ ) . 'includes/class-openedx-commerce.php';
  *
  * @since    1.0.0
  */
-function run_openedx_commerce_plugin() {
+function openedx_commerce_plugin_run() {
 
 	$plugin = new Openedx_Commerce();
 	$plugin->run();
 }
-run_openedx_commerce_plugin();
+openedx_commerce_plugin_run();

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -18,6 +18,11 @@
 
     <rule ref="WordPress">
     </rule>
+    <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
+	<properties>
+		<property name="prefixes" type="array" value="openedx_commerce" />
+	</properties>
+    </rule>
 
     <rule ref="WordPress.WP.I18n">
         <properties>

--- a/public/class-openedx-commerce-public.php
+++ b/public/class-openedx-commerce-public.php
@@ -9,7 +9,7 @@
  * @subpackage Openedx_Commerce/public
  */
 
-namespace OpenedXCommerce\public;
+namespace OpenedX_Commerce\public;
 
 /**
  * The public-facing functionality of the plugin.

--- a/test/class-enrollment-test.php
+++ b/test/class-enrollment-test.php
@@ -6,11 +6,11 @@
  * @subpackage openedx-commerce/tests
  */
 
-namespace OpenedXCommerce\tests;
+namespace OpenedX_Commerce\tests;
 
-use OpenedXCommerce\model\Openedx_Commerce_Enrollment;
-use OpenedXCommerce\model\Openedx_Commerce_Post_Type;
-use OpenedXCommerce\admin\Openedx_Commerce_Admin;
+use OpenedX_Commerce\model\Openedx_Commerce_Enrollment;
+use OpenedX_Commerce\model\Openedx_Commerce_Post_Type;
+use OpenedX_Commerce\admin\Openedx_Commerce_Admin;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/utils/openedx-utils.php
+++ b/utils/openedx-utils.php
@@ -6,7 +6,7 @@
  * @since 1.6.0
  */
 
-namespace OpenedXCommerce\utils;
+namespace OpenedX_Commerce\utils;
 
 /**
  * Enrollment Request mode options.


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy. Try to fill out the template well.
-->

## Description

This PR adds principally a rule for the naming convention prefix check in the phpcs.xml:
```xml
<rule ref="WordPress.NamingConventions.PrefixAllGlobals">
	<properties>
		<property name="prefixes" type="array" value="openedx_commerce" />
	</properties>
</rule>
```
Following the best practice for naming: https://developer.wordpress.org/plugins/plugin-basics/best-practices/#avoid-naming-collisions

The rest of the changes are adapting the namespace to that format.

## Testing instructions

This is already uploaded in our stage WordPress installation. You can check if nothing breaks.
[Credentials](https://share.1password.com/s#uRdQVE_rs5g-3RyrtYudPwWBrF6gfWFIqeZvAVDg0V8)

## Additional information

Error from WordPress.org:

> Generic function/class/define/namespace/option names
> 
> All plugins must have unique function names, namespaces, defines, class and option names. This prevents your plugin from conflicting with other plugins or themes. We need you to update your plugin to use more unique and distinct names.
> 
> A good way to do this is with a prefix. For example, if your plugin is called "Easy Custom Post Types" then you could use names like these:
> function ecpt_save_post()
> define( 'ECPT_LICENSE', true );
> class ECPT_Admin{}
> namespace ECPT;
> update_option( 'ecpt_settings', $settings );
> 
> Don't try to use two (2) or three (3) letter prefixes anymore. We host nearly 100-thousand plugins on WordPress.org alone. There are tens of thousands more outside our servers. Believe us, you’re going to run into conflicts.
> 
> You also need to avoid the use of __ (double underscores), wp_ , or _ (single underscore) as a prefix. Those are reserved for WordPress itself. You can use them inside your classes, but not as stand-alone function.
> 
> Please remember, if you're using _n() or __() for translation, that's fine. We're only talking about functions you've created for your plugin, not the core functions from WordPress. In fact, those core features are why you need to not use those prefixes in your own plugin! You don't want to break WordPress for your users.
> 
> Related to this, using if (!function_exists('NAME')) { around all your functions and classes sounds like a great idea until you realize the fatal flaw. If something else has a function with the same name and their code loads first, your plugin will break. Using if-exists should be reserved for shared libraries only.
> 
> Remember: Good prefix names are unique and distinct to your plugin. This will help you and the next person in debugging, as well as prevent conflicts.
> 
> Analysis result:
>  This plugin is using the prefix "openedxcommerce" for 7 element(s).
>  This plugin is using the prefix "openedx" for 8 element(s).
> 
>  Looks like there are elements not using common prefixes.
> openedx-commerce/openedx-commerce.php:41 function activate_openedx_commerce_plugin
> openedx-commerce/openedx-commerce.php:50 function deactivate_openedx_commerce_plugin
> openedx-commerce/openedx-commerce.php:58 function create_enrollment_logs_table
> openedx-commerce/openedx-commerce.php:107 function run_openedx_commerce_plugin

When the report said that we use openedxcommerce in 7 elements as a prefix, it refers to the namespaces. The openedx in 8 elements is for the openedx_commerce in some function names, and it is taking only the first part.

## Checklist for Merge

- [x] Tested in a remote environment
- [x] Updated documentation
- [x] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
