### PR TITLE
docs: update doc urls and the test up to 6.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ To report a bug or request a feature, visit [issues](https://github.com/openedx/
 
 ## Documentation
 
-See [documentation on Read the Docs](https://edunext-docs-openedx-woocommerce-plugin.readthedocs-hosted.com/en/latest/index.html).
+See [documentation on Read the Docs](https://docs.openedx.org/projects/wordpress-ecommerce-plugin/en/latest/index.html).
 
 
 # How to Contribute

--- a/README.txt
+++ b/README.txt
@@ -2,7 +2,7 @@
 Contributors: felipemontoya, julianrg2, mafermazu
 Tags: openedx, open edx, ecommerce, lms, courses
 Requires at least: 6.3
-Tested up to: 6.3
+Tested up to: 6.5
 Requires PHP: 8.0
 Stable tag: 2.0.3
 License: GPLv2 or later
@@ -38,8 +38,8 @@ Obtain enrollment information: This requests the Open edX APIs to retrieve the e
 
 Below are some links to help you get started with Open edX WooCommerce Plugin:
 
-- <a href="https://edunext-docs-openedx-woocommerce-plugin.readthedocs-hosted.com/en/latest/plugin_quickstart.html" target="_blank">Quick Start Guide</a>
-- <a href="https://edunext-docs-openedx-woocommerce-plugin.readthedocs-hosted.com/en/latest/how-tos/index.html" target="_blank">How-to Guides</a>
+- <a href="https://docs.openedx.org/projects/wordpress-ecommerce-plugin/en/latest/plugin_quickstart.html" target="_blank">Quick Start Guide</a>
+- <a href="https://docs.openedx.org/projects/wordpress-ecommerce-plugin/en/latest/how-tos/index.html" target="_blank">How-to Guides</a>
 
 **Note**
 
@@ -79,7 +79,7 @@ Let's start installing and configuring the Open edx Commerce plugin to connect y
 
 = Where can I find documentation and user guides? =
 
-If you need help setting up and configuring this plugin, visit the [documentation on Read the Docs].(https://edunext-docs-openedx-woocommerce-plugin.readthedocs-hosted.com/en/latest/index.html) 
+If you need help setting up and configuring this plugin, visit the [documentation on Read the Docs].(https://docs.openedx.org/projects/wordpress-ecommerce-plugin/en/latest/index.html) 
 
 = Where can I report bugs or request features? =
 

--- a/admin/views/class-openedx-commerce-settings.php
+++ b/admin/views/class-openedx-commerce-settings.php
@@ -321,7 +321,7 @@ class Openedx_Commerce_Settings {
 	 */
 	public function openedx_settings_section_callback() {
 		printf(
-			'Configuring the necessary parameters here to establish the connection between this plugin and your Open edX platform. For more information, you can visit the how-to <a href="https://edunext-docs-openedx-woocommerce-plugin.readthedocs-hosted.com/en/latest/how-tos/create_an_openedx_app.html">Create an Open edX Application for the Plugin Settings</a> in the documentation.'
+			'Configuring the necessary parameters here to establish the connection between this plugin and your Open edX platform. For more information, you can visit the how-to <a href="https://docs.openedx.org/projects/wordpress-ecommerce-plugin/en/latest/how-tos/create_an_openedx_app.html">Create an Open edX Application for the Plugin Settings</a> in the documentation.'
 		);
 	}
 }


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy. Try to fill out the template well.
-->

## Description

This PR updates the documentation URL to the Open edX WordPress Commerce doc URL and fixes the Test up to use the latest version.

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
