### PR TITLE
fix: stop using an empty enqued style in all contexts

### DIFF
--- a/public/class-openedx-commerce-public.php
+++ b/public/class-openedx-commerce-public.php
@@ -72,8 +72,6 @@ class Openedx_Commerce_Public {
 		 * between the defined hooks and the functions defined in this
 		 * class.
 		 */
-
-		wp_enqueue_style( $this->plugin_name, plugin_dir_url( __FILE__ ) . 'css/openedx-commerce-public.css', array(), $this->version, 'all' );
 	}
 
 	/**

--- a/public/css/openedx-commerce-public.css
+++ b/public/css/openedx-commerce-public.css
@@ -1,4 +1,7 @@
 /**
  * All of the CSS for your public-facing functionality should be
  * included in this file.
+ *
+ * Note: This file is not queued; you must queue it if you want to add styles here.
+ * For more information on why we dequeued this file, see https://github.com/openedx/openedx-wordpress-ecommerce/pull/79.
  */


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy. Try to fill out the template well.
-->

## Description

This is a quick fix to avoid loading the `openedx-commerce-public.css` in all contexts.

I pass the plugin in a [Plugin Checker.](https://wordpress.org/plugins/plugin-check/) to check we follow the WordPress standards. And I found this warning:
![Screenshot from 2024-06-06 14-58-39](https://github.com/openedx/openedx-wordpress-ecommerce/assets/35668326/95895196-8d2d-4ee0-bd27-3b1d57f0d26b)


I only removed the queued action because it is not needed. The `openedx-commerce-public.css` doesn't have styles.

With this PR, the plugin checker responds the following:
![Screenshot from 2024-06-06 15-01-03](https://github.com/openedx/openedx-wordpress-ecommerce/assets/35668326/041a1272-7254-46eb-afe5-694c9001bea0)

## Testing instructions

Check if everything is alright in our stage. This version is in our stage: https://share.1password.com/s#ywKsPlWEUFR__qx_a_ZyoT1jyd8DUJQUs4ycraieSRg


## Checklist for Merge

- [x] Tested in a remote environment
- [x] Rebased master/main
- [x] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
