### PR TITLE
docs: add info about tutor-contrib-wordpress plugin

### DIFF
--- a/docs/source/how-tos/create_an_openedx_app.rst
+++ b/docs/source/how-tos/create_an_openedx_app.rst
@@ -37,7 +37,7 @@ Create an Open edX Application to Configure the Open edX Commerce plugin
     .. image:: /_images/how-tos/create_an_openedx_app/openedx-sync-plugin-settings.png
         :alt: Open edX Sync Plugin Settings
 
-#. Test the credentials by clicking **Save Changes** and **Generate JWT Token**. 
+#. Test the credentials by clicking **Save Changes** and **Generate JWT Token**.
 
 .. note:: If you do not have credentials to enter the Django Admin, you need to contact an operator of your Open edX instance to provide you the **client id and client secret of an Application** with **Client Credentials** as **Authorization grant type** and **staff user**.
 

--- a/docs/source/how-tos/create_an_openedx_app.rst
+++ b/docs/source/how-tos/create_an_openedx_app.rst
@@ -3,6 +3,9 @@ Create an Open edX Application for the Plugin Settings
 
 You will learn how to create an Open edX Application for filling out the form in the Open edX Sync Plugin Settings in our WordPress Settings.
 
+If you are using `Tutor`_ for managing your Open edX instance, you can install `tutor-contrib-wordpress`_ and use its commands assist with the
+configuration and integration of the Open edX platform with an existing WordPress site.
+
 Index
 -------
 - `Requisites`_
@@ -42,3 +45,6 @@ Next Steps
 -----------
 
 - :doc:`How-to: Create enrollment requests manually </how-tos/create_enrollment_requests_manually>`.
+
+.. _Tutor: https://docs.tutor.edly.io
+.. _tutor-contrib-wordpress: https://github.com/CodeWithEmad/tutor-contrib-wordpress

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -19,7 +19,7 @@ User Guide
     tutorials/index
     how-tos/index
     decisions/index
-    
+
 
 
 Open edX Compatibility

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -10,31 +10,31 @@
     <exclude-pattern>index.php</exclude-pattern>
     <exclude-pattern>composer-setup.php</exclude-pattern>
 
-    <arg value="sp"/>
-    <arg name="basepath" value="./"/>
-    <arg name="colors"/>
-    <arg name="extensions" value="php"/>
-    <arg name="parallel" value="8"/>
+    <arg value="sp" />
+    <arg name="basepath" value="./" />
+    <arg name="colors" />
+    <arg name="extensions" value="php" />
+    <arg name="parallel" value="8" />
 
     <rule ref="WordPress">
     </rule>
     <rule ref="WordPress.NamingConventions.PrefixAllGlobals">
-	<properties>
-		<property name="prefixes" type="array" value="openedx_commerce" />
-	</properties>
+        <properties>
+            <property name="prefixes" type="array" value="openedx_commerce" />
+        </properties>
     </rule>
 
     <rule ref="WordPress.WP.I18n">
         <properties>
             <property name="text_domain" type="array">
-                <element value="openedx-commerce"/>
+                <element value="openedx-commerce" />
             </property>
         </properties>
     </rule>
 
     <rule ref="Generic.Files.LineEndings">
         <properties>
-            <property name="eolChar" value="\n"/>
+            <property name="eolChar" value="\n" />
         </properties>
     </rule>
 


### PR DESCRIPTION
This will introduce the `tutor-contrib-wordpress` plugin for `tutor` inside documents. also, clean up some tailing whitespace and reformat an XML file. 