### PR TITLE
fix: add the composer.json to the zip file

### DIFF
--- a/.github/workflows/upload-release-zip.yml
+++ b/.github/workflows/upload-release-zip.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           type: 'zip'
           filename: 'openedx-commerce.zip'
-          exclusions: '*.git* .* /test/* /requirements/* /docs/* composer.* *.yaml *.xml Makefile'
+          exclusions: '*.git* .* /test/* /requirements/* /docs/* composer.lock *.yaml *.xml Makefile'
 
       - name: Upload zip to latest release
         uses: xresloader/upload-to-github-release@v1


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy. Try to fill out the template well.
-->

## Description

This PR changes the exclusion option to avoid only the `composer.lock` and have the `composer.json` in the zip file.

Related #85 

## Notes
I only add the `composer.json` because it is the problem in #85 

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
