### PR TITLE
fix: correct the text domains

### DIFF
--- a/admin/class-openedx-commerce-admin.php
+++ b/admin/class-openedx-commerce-admin.php
@@ -216,8 +216,8 @@ class Openedx_Commerce_Admin {
 		$type_options['wild_card'] = array(
 			'id'            => 'is_openedx_course',
 			'wrapper_class' => 'show_if_simple',
-			'label'         => __( 'Open edX Course', 'woocommerce' ),
-			'description'   => __( 'Check this box if the product is an Open edX Course', 'woocommerce' ),
+			'label'         => __( 'Open edX Course', 'openedx-commerce' ),
+			'description'   => __( 'Check this box if the product is an Open edX Course', 'openedx-commerce' ),
 			'default'       => $checked,
 		);
 		return $type_options;
@@ -257,14 +257,14 @@ class Openedx_Commerce_Admin {
 		woocommerce_wp_text_input(
 			array(
 				'id'          => '_course_id',
-				'label'       => __( 'Open edX Course ID', 'woocommerce' ),
+				'label'       => __( 'Open edX Course ID', 'openedx-commerce' ),
 				'placeholder' => '',
 				'desc_tip'    => 'true',
 				'description' => __(
 					'Ex: course-v1:edX+DemoX+Demo_Course.
 					<br><br> You can find the Open edX Course ID
 					in the URL of your course in your LMS.',
-					'woocommerce',
+					'openedx-commerce',
 				),
 			)
 		);
@@ -272,12 +272,12 @@ class Openedx_Commerce_Admin {
 		woocommerce_wp_select(
 			array(
 				'id'          => '_mode',
-				'label'       => __( 'Open edX Course Mode', 'woocommerce' ),
+				'label'       => __( 'Open edX Course Mode', 'openedx-commerce' ),
 				'desc_tip'    => 'true',
 				'description' => __(
 					'Select the mode for your course. 
 					Make sure to set a mode that your course has.',
-					'woocommerce',
+					'openedx-commerce',
 				),
 				'options'     => utils\get_enrollment_options(),
 			)
@@ -293,7 +293,7 @@ class Openedx_Commerce_Admin {
 	 */
 	public function add_custom_column_order_items() {
 		echo '<th>' .
-			esc_html__( 'Related Enrollment Request', 'woocommerce' ) .
+			esc_html__( 'Related Enrollment Request', 'openedx-commerce' ) .
 			'</th>';
 	}
 
@@ -351,7 +351,7 @@ class Openedx_Commerce_Admin {
 		} else {
 
 			$html_output  = '<td>';
-			$html_output .= esc_html__( 'Product is not an Open edX Course', 'woocommerce' );
+			$html_output .= esc_html__( 'Product is not an Open edX Course', 'openedx-commerce' );
 			$html_output .= '</td>';
 
 			echo wp_kses(

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -28,7 +28,6 @@
         <properties>
             <property name="text_domain" type="array">
                 <element value="openedx-commerce"/>
-                <element value="woocommerce"/>
             </property>
         </properties>
     </rule>


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy. Try to fill out the template well.
-->

## Description

This PR corrects the text domain, changing `'woocommerce'` to `'openedx-commerce'`, our text-domain. And remove the `'woocommerce'` text domain for the names allowed in our tests.

This PR is related to #87 

## Testing instructions

- The WP Coding Standard tests are passing.
- You can use this zip version in your environment.
[openedx-commerce-PR89.zip](https://github.com/user-attachments/files/16850775/openedx-commerce-PR89.zip)
- This was also tested in our stage:
https://share.1password.com/s#h_dXnkCnTpVD8gLqKEs5nDXHN6N2CzWVtSdh3qoMTT4

## Checklist for Merge

- [x] Tested in a remote environment
- [x] Rebased master/main
- [x] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
