### PR TITLE
test: add the wordpress plugin check action

### DIFF
--- a/.github/workflows/upload-release-zip.yml
+++ b/.github/workflows/upload-release-zip.yml
@@ -19,12 +19,16 @@ jobs:
         with:
           composer-options: "--no-dev"
 
+      - name: Prepare the openedx-commerce directory for the release
+        run: |
+          make release
+
       - name: Archive Release
         uses: thedoctor0/zip-release@0.7.6
         with:
           type: 'zip'
-          filename: 'openedx-commerce.zip'
-          exclusions: '*.git* .* /test/* /requirements/* /docs/* composer.lock *.yaml *.xml Makefile'
+          command: 'cd ./openedx-commerce'
+          filename: '../openedx-commerce.zip'
 
       - name: Upload zip to latest release
         uses: xresloader/upload-to-github-release@v1

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -1,0 +1,27 @@
+name: 'WordPress Plugin Check'
+on:
+  pull_request
+
+jobs:
+  check:
+    name: Plugin Check
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Install Composer dependencies
+      uses: ramsey/composer-install@v3
+      with:
+        composer-options: "--no-dev"
+
+    # Prepare the plugin as we prepare it in the ZIP creation
+    - name: Create openedx-commerce directory and copy files
+      run: |
+        mkdir openedx-commerce
+        rsync -av --exclude='*.git*' --exclude='.*' --exclude='/test/*' --exclude='/requirements/*' --exclude='/docs/*' --exclude='composer.lock' --exclude='*.yaml' --exclude='*.xml' --exclude='Makefile' ./ openedx-commerce/
+
+    - name: Run plugin check
+      uses: wordpress/plugin-check-action@v1
+      with:
+        build-dir: './openedx-commerce'

--- a/.github/workflows/wordpress-plugin-check.yml
+++ b/.github/workflows/wordpress-plugin-check.yml
@@ -15,11 +15,9 @@ jobs:
       with:
         composer-options: "--no-dev"
 
-    # Prepare the plugin as we prepare it in the ZIP creation
-    - name: Create openedx-commerce directory and copy files
+    - name: Prepare the openedx-commerce directory for the release
       run: |
-        mkdir openedx-commerce
-        rsync -av --exclude='*.git*' --exclude='.*' --exclude='/test/*' --exclude='/requirements/*' --exclude='/docs/*' --exclude='composer.lock' --exclude='*.yaml' --exclude='*.xml' --exclude='Makefile' ./ openedx-commerce/
+        make release
 
     - name: Run plugin check
       uses: wordpress/plugin-check-action@v1

--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,13 @@ requirements:
 serve_docs: ## serve the built docs locally to preview the site in the browser
 	sphinx-autobuild docs/source $(BUILDDIR)/html
 
+# Create the openedx-commerce directory with the needed files for the release.
+release:
+	mkdir openedx-commerce
+	rsync -av --exclude='*.git*' --exclude='.*' --exclude='/test/*' \
+	--exclude='/requirements/*' --exclude='/docs/*' --exclude='composer.lock' \
+	--exclude='*.yaml' --exclude='*.xml' --exclude='Makefile' ./ openedx-commerce/
+
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
 %: Makefile


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy. Try to fill out the template well.
-->

## Description

This PR adds a GitHub workflow to run [WordPress/plugin-check-action](https://github.com/WordPress/plugin-check-action).

This PR also refactors the workflows.
The zip version generated with this PR is: [openedx-commerce.zip](https://github.com/user-attachments/files/16897592/openedx-commerce.zip)


## Testing instructions

The test `WordPress Plugin Check / Plugin Check` passed.

## Additional information

This test mounts a WordPress environment, installs our plugin using a version similar to our ZIP release, activates the plugin in this new environment, installs the [Plugin check (PCP)](https://wordpress.org/plugins/plugin-check/) by WordPress Performance Team and Plugin Review Team, and run the test over our plugin.

Checks tested: `i18n_usage`, `code_obfuscation`, `direct_db_queries`, `enqueued_scripts_in_footer`, `enqueued_scripts_size`, `enqueued_styles_scope`, `file_type`, `late_escaping`, `localhost`, `no_unfiltered_uploads`, `performant_wp_query_params`, `plugin_header_text_domain`, `plugin_readme`, `plugin_review_phpcs`, `plugin_updater`, `trademarks`.

Categories tested: `accessibility`, `general`, `performance`, `plugin_repo`, `security`.

More info in: [WordPress/plugin-check-action](https://github.com/WordPress/plugin-check-action)

> [!IMPORTANT]  
> This will increase the test execution time by ~ 2 minutes.

## Checklist for Merge

- [x] Tested in a remote environment
- [ ] Updated documentation
- [x] Rebased master/main
- [x] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
