### PR TITLE
fix: admin enqueue order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## v2.0.7 - 2024-11-05
+
+### [2.0.7](https://github.com/openedx/openedx-wordpress-ecommerce/compare/v2.0.6...v2.0.7) (2024-11-05)
+
+#### Bug Fixes
+
+* fix: admin enqueue order (#102)
+
+### Documentation
+
+* docs: add info about tutor-contrib-wordpress plugin (#84)
+
 ## v2.0.6 - 2024-10-03
 
 ### [2.0.6](https://github.com/openedx/openedx-wordpress-ecommerce/compare/v2.0.5...v2.0.6) (2024-10-03)

--- a/README.txt
+++ b/README.txt
@@ -4,7 +4,7 @@ Tags: openedx, open edx, ecommerce, lms, courses
 Requires at least: 6.3
 Tested up to: 6.6
 Requires PHP: 8.0
-Stable tag: 2.0.6
+Stable tag: 2.0.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/admin/class-openedx-commerce-admin.php
+++ b/admin/class-openedx-commerce-admin.php
@@ -111,6 +111,14 @@ class Openedx_Commerce_Admin {
 		 * between the defined hooks and the functions defined in this
 		 * class.
 		 */
+
+		wp_enqueue_style(
+			$this->plugin_name,
+			plugin_dir_url( __FILE__ ) . '../admin/css/class-openedx-commerce-admin.css',
+			array(),
+			$this->version,
+			'all'
+		);
 	}
 
 	/**

--- a/admin/class-openedx-commerce-admin.php
+++ b/admin/class-openedx-commerce-admin.php
@@ -133,6 +133,12 @@ class Openedx_Commerce_Admin {
 		 * between the defined hooks and the functions defined in this
 		 * class.
 		 */
+
+		wp_register_script( 'product-type-script', plugin_dir_url( __FILE__ ) . '../admin/js/product-type.js', array(), $this->version, true );
+		wp_enqueue_script( 'product-type-script' );
+
+		wp_register_script( 'course-id-restriction-script', plugin_dir_url( __FILE__ ) . '../admin/js/course-id-restriction.js', array(), $this->version, true );
+		wp_enqueue_script( 'course-id-restriction-script' );
 	}
 
 	/**

--- a/admin/class-openedx-commerce-admin.php
+++ b/admin/class-openedx-commerce-admin.php
@@ -179,7 +179,7 @@ class Openedx_Commerce_Admin {
 	 *
 	 * @return object              Post type class object
 	 */
-	public function register_post_type( $post_type = '', $plural = '', $single = '', $description = '', array $options ) {
+	public function register_post_type( $post_type = '', $plural = '', $single = '', $description = '', array $options = array() ) {
 
 		if ( ! $post_type || ! $plural || ! $single ) {
 			return;
@@ -205,7 +205,7 @@ class Openedx_Commerce_Admin {
 		$plural = '',
 		$single = '',
 		$description = '',
-		array $options
+		array $options = array()
 	) {
 		return new Openedx_Commerce_Post_Type( $post_type, $plural, $single, $description, $options );
 	}

--- a/includes/class-openedx-commerce.php
+++ b/includes/class-openedx-commerce.php
@@ -76,7 +76,6 @@ class Openedx_Commerce {
 		$this->define_admin_hooks();
 		$this->define_public_hooks();
 		$this->define_plugin_settings_hooks();
-		$this->define_enqueue_scripts();
 	}
 
 	/**
@@ -262,20 +261,6 @@ class Openedx_Commerce {
 
 		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_styles' );
 		$this->loader->add_action( 'wp_enqueue_scripts', $plugin_public, 'enqueue_scripts' );
-	}
-
-	/**
-	 * Register all the hooks related to custom scripts for specific functionalities.
-	 *
-	 * @since    1.11.0
-	 * @access   private
-	 */
-	private function define_enqueue_scripts() {
-		wp_register_script( 'product-type-script', plugin_dir_url( __FILE__ ) . '../admin/js/product-type.js', array(), $this->get_version(), true );
-		wp_enqueue_script( 'product-type-script' );
-
-		wp_register_script( 'course-id-restriction-script', plugin_dir_url( __FILE__ ) . '../admin/js/course-id-restriction.js', array(), $this->get_version(), true );
-		wp_enqueue_script( 'course-id-restriction-script' );
 	}
 
 	/**

--- a/includes/class-openedx-commerce.php
+++ b/includes/class-openedx-commerce.php
@@ -216,13 +216,6 @@ class Openedx_Commerce {
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_styles' );
 		$this->loader->add_action( 'admin_enqueue_scripts', $plugin_admin, 'enqueue_scripts' );
 		$this->loader->add_filter( 'gettext', $this, 'openedx_plugin_custom_post_message', 10, 3 );
-		$this->loader->wp_enqueue_style(
-			$this->plugin_name,
-			plugin_dir_url( __FILE__ ) . '../admin/css/class-openedx-commerce-admin.css',
-			array(),
-			$this->version,
-			'all'
-		);
 
 		// Redirection from enrollment to order and enrollment to order.
 		$this->loader->add_filter( 'woocommerce_admin_order_item_headers', $plugin_admin, 'add_custom_column_order_items' );

--- a/openedx-commerce.php
+++ b/openedx-commerce.php
@@ -3,7 +3,7 @@
  * Plugin Name:       Open edX Commerce
  * Plugin URI:        https://github.com/openedx/openedx-wordpress-ecommerce
  * Description:       Easily connect your WooCommerce store to Open edX.
- * Version:           2.0.6
+ * Version:           2.0.7
  * Author:            Open edX Community
  * Author URI:        https://github.com/openedx/openedx-wordpress-ecommerce
  * License:           GPL-2.0+
@@ -32,7 +32,7 @@ if ( ! defined( 'WPINC' ) ) {
  * Start at version 1.0.0 and use SemVer - https://semver.org
  * Rename this for your plugin and update it as you release new versions.
  */
-define( 'OPENEDX_COMMERCE_VERSION', '2.0.6' );
+define( 'OPENEDX_COMMERCE_VERSION', '2.0.7' );
 
 /**
  * The code that runs during plugin activation.


### PR DESCRIPTION
<!--
Please give your pull request a short but descriptive title.
Use conventional commits to separate and summarize commits logically:
https://www.conventionalcommits.org/en/v1.0.0/

Use this template as a guide. Omit sections that don't apply.

🙈 Don't be lazy. Try to fill out the template well.
-->

## Description

This PR is for fix #101 

- Move the enqueue scripts from `includes/class-openedx-commerce.php` to the admin enqueue_scripts (`admin/class-openedx-commerce-admin.php`).
- Remove the `define_enqueue_scripts` function from `includes/class-openedx-commerce.php` because it is no longer needed.
- Move the enqueue style from `includes/class-openedx-commerce.php` to the admin enqueue_styles (`admin/class-openedx-commerce-admin.php`).
- Provide a default value to options because it is a required parameter.

## Testing instructions

Use this version and:
- Check the boxes in Enrollment Operation Logs in the Enrollment Requests.
- Check the Open edX Course box in a WooCommerce product.

## Screenshots
This video shows how every commit resolves a note/warning in the admin dashboard and, at the end, shows how this does not affect the js and the plugin's styles.

[Screencast from 2024-11-01 11-10-07.webm](https://github.com/user-attachments/assets/a5ebbf16-de0a-4e69-ad9d-1868619c5205)

Note: In the video, the Enrollment Operation Logs in the Enrollment Requests don't show all the borders colored, but they are.

![image](https://github.com/user-attachments/assets/bbcad74e-3533-47b6-ab49-5dddf4dce357)


## Checklist for Merge

- [x] Tested in a remote environment
- [x] Updated documentation (NA)
- [x] Rebased master/main
- [ ] Squashed commits

<!--
You can put NA in the checklist if it doesn't apply

- [x] Check that dont't apply / NA
-->
